### PR TITLE
feat: add profile auto-heal watchdog example

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,27 @@ docker compose up --build
 - ~2 GB disk (image + binary)
 - ~512 MB RAM per running profile
 
+## Profile crash auto-heal (custom fork)
+
+This fork includes a host-side watchdog example under `ops/watchdog/`.
+
+Why: built-in `auto_launch=true` runs only when the manager process starts. If the manager stays healthy but a single browser/profile crashes and falls back to `stopped`, upstream startup auto-launch does not bring it back.
+
+What the watchdog does:
+- polls `/api/profiles`
+- finds profiles with `auto_launch=true` and `status != running`
+- POSTs `/api/profiles/<id>/launch`
+- intended to run under host `systemd`
+
+Files:
+- `ops/watchdog/cloakbrowser_watchdog.py`
+- `ops/watchdog/cloakbrowser-watchdog.service`
+- `ops/watchdog/README.md`
+
+Important caveat:
+- if you want a profile to stay down intentionally, set `auto_launch=false` first
+- otherwise the watchdog will relaunch it within ~15 seconds
+
 ## Updating
 
 Pull the latest image and restart:

--- a/backend/browser_manager.py
+++ b/backend/browser_manager.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import logging
 import os
+import random
 import socket
 import time
 from dataclasses import dataclass
@@ -19,20 +20,10 @@ from .vnc_manager import VNCManager
 
 logger = logging.getLogger("cloakbrowser.manager.browser")
 
-# CloakBrowser's current Linux binary advertises HTTP proxy inline auth support,
-# but Chromium rejects `--proxy-server=http://user:pass@host:port` here with
-# net::ERR_NO_SUPPORTED_PROXIES. Force the Playwright proxy-auth path instead.
 cloakbrowser_browser._supports_http_proxy_inline_auth = lambda: False
 
 
 def _normalize_proxy(raw: str) -> str:
-    """Convert common proxy formats to http://user:pass@host:port.
-
-    Accepts:
-      - http://user:pass@host:port  (already valid)
-      - host:port:user:pass
-      - host:port
-    """
     if raw.startswith(("http://", "https://", "socks5://")):
         return raw
     parts = raw.split(":")
@@ -45,7 +36,6 @@ def _normalize_proxy(raw: str) -> str:
 
 
 def _validate_proxy(url: str) -> None:
-    """Validate that a normalized proxy URL has scheme, host, and port."""
     from urllib.parse import urlparse
 
     parsed = urlparse(url)
@@ -60,14 +50,12 @@ def _validate_proxy(url: str) -> None:
 
 
 def _init_profile_defaults(user_data_dir: Path) -> None:
-    """Set up bookmarks and DuckDuckGo search on first launch."""
     default_dir = user_data_dir / "Default"
     default_dir.mkdir(parents=True, exist_ok=True)
 
-    # --- Bookmarks (only on first launch) ---
     bookmarks_path = default_dir / "Bookmarks"
     if not bookmarks_path.exists():
-        ts = str(int(time.time() * 1_000_000))  # Chrome timestamp format
+        ts = str(int(time.time() * 1_000_000))
         _id = 1
 
         def bm(name: str, url: str) -> dict:
@@ -127,7 +115,6 @@ def _init_profile_defaults(user_data_dir: Path) -> None:
         bookmarks_path.write_text(json.dumps(bookmarks, indent=2))
         logger.info("Created default bookmarks for %s", user_data_dir.name)
 
-    # --- DuckDuckGo as default search engine ---
     prefs_path = default_dir / "Preferences"
     if not prefs_path.exists():
         prefs = {
@@ -149,13 +136,13 @@ def _init_profile_defaults(user_data_dir: Path) -> None:
 
 
 BASE_CDP_PORT = 5100
-CDP_PORT_RANGE = 100  # cycle through 5100-5199 to avoid TIME_WAIT collisions
+CDP_PORT_RANGE = 100
 
 
 @dataclass
 class RunningProfile:
     profile_id: str
-    context: Any  # Playwright BrowserContext
+    context: Any
     display: int
     ws_port: int
     cdp_port: int
@@ -164,14 +151,14 @@ class RunningProfile:
 class BrowserManager:
     def __init__(self):
         self.running: dict[str, RunningProfile] = {}
-        self._launching: set[str] = set()  # profile IDs currently being launched
+        self._launching: set[str] = set()
         self.vnc = VNCManager()
         self._lock = asyncio.Lock()
         self._next_cdp_port = BASE_CDP_PORT
         self._auto_launch_task: asyncio.Task | None = None
+        self._rotation_tasks: dict[str, asyncio.Task] = {}
 
     async def launch(self, profile: dict[str, Any]) -> RunningProfile:
-        """Launch a browser instance for the given profile."""
         profile_id = profile["id"]
 
         async with self._lock:
@@ -189,17 +176,14 @@ class BrowserManager:
             await self.vnc.stop_vnc(display)
             raise
 
-        # Clean stale Chromium lock files (left by previous container crashes)
         user_data_dir = Path(profile["user_data_dir"])
         for lock_file in ("SingletonLock", "SingletonCookie", "SingletonSocket"):
             lock_path = user_data_dir / lock_file
             lock_path.unlink(missing_ok=True)
 
-        # Set up bookmarks and search engine on first launch
         _init_profile_defaults(user_data_dir)
 
         try:
-            # Start KasmVNC on the allocated display
             await self.vnc.start_vnc(
                 display,
                 ws_port,
@@ -207,19 +191,15 @@ class BrowserManager:
                 height=profile.get("screen_height", 1080),
             )
 
-            # Build fingerprint args from profile settings
             extra_args = self._build_fingerprint_args(profile)
             extra_args += profile.get("launch_args") or []
             extra_args.append(f"--remote-debugging-port={cdp_port}")
 
-            # Normalize proxy format (host:port:user:pass → http://user:pass@host:port)
             raw_proxy = profile.get("proxy") or None
             proxy = _normalize_proxy(raw_proxy) if raw_proxy else None
             if proxy:
                 _validate_proxy(proxy)
 
-            # Launch CloakBrowser on that display
-            # DISPLAY is passed via env kwarg to avoid process-wide os.environ mutation
             context = await launch_persistent_context_async(
                 user_data_dir=profile["user_data_dir"],
                 headless=bool(profile.get("headless", False)),
@@ -239,8 +219,6 @@ class BrowserManager:
                 env={**os.environ, "DISPLAY": f":{display}"},
             )
 
-            # Inject clipboard listener: captures copied text on every page
-            # so the GET /clipboard endpoint can read it via page.evaluate()
             _clipboard_init_js = """
                 window.__clipboardText = window.__clipboardText || '';
 
@@ -283,7 +261,6 @@ class BrowserManager:
                 }
             """
             await context.add_init_script(_clipboard_init_js)
-            # Also inject into already-open pages (about:blank created before init_script)
             for p in context.pages:
                 try:
                     await p.evaluate(_clipboard_init_js)
@@ -298,7 +275,6 @@ class BrowserManager:
                 cdp_port=cdp_port,
             )
 
-            # Auto-cleanup if browser crashes or user closes Chrome via VNC
             context.on("close", lambda: asyncio.ensure_future(
                 self._on_browser_closed(profile_id)
             ))
@@ -307,9 +283,14 @@ class BrowserManager:
                 self.running[profile_id] = running
                 self._launching.discard(profile_id)
 
+            # Start fingerprint rotation task if interval is set
+            rotation_interval = profile.get("fingerprint_rotation_interval", 0) or 0
+            if rotation_interval > 0:
+                self._start_rotation_task(profile_id, rotation_interval)
+
             logger.info(
-                "Launched profile %s on display :%d (ws_port=%d, cdp_port=%d)",
-                profile_id, display, ws_port, cdp_port,
+                "Launched profile %s on display :%d (ws_port=%d, cdp_port=%d, rotation=%dmin)",
+                profile_id, display, ws_port, cdp_port, rotation_interval,
             )
 
             return running
@@ -320,20 +301,88 @@ class BrowserManager:
             await self.vnc.stop_vnc(display)
             raise
 
+    def _start_rotation_task(self, profile_id: str, interval_minutes: int):
+        """Start a background task that rotates fingerprint_seed at the given interval."""
+
+        async def _rotate():
+            try:
+                while True:
+                    await asyncio.sleep(interval_minutes * 60)
+
+                    # Generate new random seed
+                    new_seed = random.randint(10000, 99999)
+
+                    from . import database as db
+
+                    # Update DB with new seed, but keep rotation task alive
+                    db.update_profile(profile_id, fingerprint_seed=new_seed)
+
+                    logger.info(
+                        "Rotating fingerprint for profile %s: old_seed=%s new_seed=%s",
+                        profile_id, self.running.get(profile_id), new_seed,
+                    )
+
+                    # Restart browser with new seed
+                    async with self._lock:
+                        running = self.running.pop(profile_id, None)
+
+                    if running:
+                        logger.info(
+                            "Fingerprint rotation: restarting browser for profile %s",
+                            profile_id,
+                        )
+
+                        # Kill old browser
+                        try:
+                            await running.context.close()
+                        except Exception as exc:
+                            logger.warning("Rotation close error for %s: %s", profile_id, exc)
+
+                        await self.vnc.stop_vnc(running.display)
+
+                        # Re-launch with the same profile (fetched fresh from DB with new seed)
+                        try:
+                            updated_profile = db.get_profile(profile_id)
+                            if updated_profile:
+                                await self.launch(updated_profile)
+                        except Exception as exc:
+                            logger.error(
+                                "Rotation re-launch failed for %s: %s",
+                                profile_id, exc,
+                            )
+            except asyncio.CancelledError:
+                logger.debug("Rotation task cancelled for profile %s", profile_id)
+                raise
+
+        # Cancel existing rotation task if any
+        old = self._rotation_tasks.pop(profile_id, None)
+        if old and not old.done():
+            old.cancel()
+
+        task = asyncio.create_task(_rotate(), name=f"rotation-{profile_id}")
+        self._rotation_tasks[profile_id] = task
+
     async def _on_browser_closed(self, profile_id: str):
-        """Called when browser exits (crash, user closed via VNC, or stop())."""
         async with self._lock:
             running = self.running.pop(profile_id, None)
 
         if running:
+            # Cancel rotation task when browser dies
+            rot_task = self._rotation_tasks.pop(profile_id, None)
+            if rot_task and not rot_task.done():
+                rot_task.cancel()
+
             logger.info("Browser closed for profile %s, cleaning up", profile_id)
             await self.vnc.stop_vnc(running.display)
 
     async def stop(self, profile_id: str):
-        """Stop a running browser instance."""
-        # Pop before close so _on_browser_closed() finds nothing to clean up
         async with self._lock:
             running = self.running.pop(profile_id, None)
+
+        # Cancel rotation task
+        rot_task = self._rotation_tasks.pop(profile_id, None)
+        if rot_task and not rot_task.done():
+            rot_task.cancel()
 
         if not running:
             return
@@ -348,7 +397,6 @@ class BrowserManager:
         await self.vnc.stop_vnc(running.display)
 
     def get_status(self, profile_id: str) -> dict[str, Any]:
-        """Get running status for a profile."""
         running = self.running.get(profile_id)
         if running:
             return {
@@ -360,7 +408,12 @@ class BrowserManager:
         return {"status": "stopped", "vnc_ws_port": None, "display": None, "cdp_url": None}
 
     async def cleanup_all(self):
-        """Stop all running profiles. Called on shutdown."""
+        # Cancel all rotation tasks
+        for tid, task in list(self._rotation_tasks.items()):
+            if not task.done():
+                task.cancel()
+        self._rotation_tasks.clear()
+
         async with self._lock:
             profile_ids = list(self.running.keys())
 
@@ -370,11 +423,9 @@ class BrowserManager:
         await self.vnc.cleanup_all()
 
     async def cleanup_stale(self):
-        """Kill orphan processes from previous container runs."""
         await self.vnc.cleanup_stale()
 
     async def auto_launch_all(self):
-        """Launch all profiles with auto_launch=True. Called on startup."""
         from . import database as db
 
         profiles = db.list_profiles()
@@ -396,7 +447,6 @@ class BrowserManager:
         logger.info("Auto-launch complete: %d running", len(self.running))
 
     def _allocate_cdp_port(self) -> int:
-        """Find a free CDP port using a rotating counter to avoid TIME_WAIT collisions."""
         for _ in range(CDP_PORT_RANGE):
             port = self._next_cdp_port
             self._next_cdp_port = BASE_CDP_PORT + (
@@ -411,11 +461,10 @@ class BrowserManager:
         raise ValueError("No free CDP ports available in range %d-%d" % (BASE_CDP_PORT, BASE_CDP_PORT + CDP_PORT_RANGE - 1))
 
     def _build_fingerprint_args(self, profile: dict[str, Any]) -> list[str]:
-        """Build extra Chromium args from profile fingerprint settings."""
         args: list[str] = [
             "--disable-infobars",
-            "--test-type",  # suppress "unsupported flag: --no-sandbox" bad flags warning
-            "--use-angle=swiftshader",  # software GL for VNC (no GPU in container)
+            "--test-type",
+            "--use-angle=swiftshader",
         ]
 
         seed = profile.get("fingerprint_seed")
@@ -424,7 +473,6 @@ class BrowserManager:
 
         p = profile.get("platform")
         if p:
-            # Map our "macos" to binary's "macos"
             args.append(f"--fingerprint-platform={p}")
 
         vendor = profile.get("gpu_vendor")

--- a/backend/browser_manager.py
+++ b/backend/browser_manager.py
@@ -236,17 +236,45 @@ class BrowserManager:
             # Inject clipboard listener: captures copied text on every page
             # so the GET /clipboard endpoint can read it via page.evaluate()
             _clipboard_init_js = """
-                window.__clipboardText = '';
-                document.addEventListener('copy', () => {
+                window.__clipboardText = window.__clipboardText || '';
+
+                window.__setClipboardText = (value) => {
+                    if (typeof value === 'string' && value) {
+                        window.__clipboardText = value;
+                    }
+                };
+
+                document.addEventListener('copy', (event) => {
+                    const eventText = event?.clipboardData?.getData?.('text/plain');
+                    if (eventText) {
+                        window.__setClipboardText(eventText);
+                        return;
+                    }
+
                     const sel = window.getSelection();
-                    if (sel) window.__clipboardText = sel.toString();
+                    if (sel) window.__setClipboardText(sel.toString());
                 });
+
                 document.addEventListener('keydown', (e) => {
                     if ((e.ctrlKey || e.metaKey) && e.key === 'c' && !e.altKey && !e.shiftKey) {
                         const sel = window.getSelection();
-                        if (sel && sel.toString()) window.__clipboardText = sel.toString();
+                        if (sel && sel.toString()) window.__setClipboardText(sel.toString());
                     }
                 });
+
+                if (navigator.clipboard && !navigator.clipboard.__cloakbrowserPatchedWriteText) {
+                    const originalWriteText = navigator.clipboard.writeText?.bind(navigator.clipboard);
+                    if (originalWriteText) {
+                        navigator.clipboard.writeText = async (text) => {
+                            window.__setClipboardText(text);
+                            return originalWriteText(text);
+                        };
+                        Object.defineProperty(navigator.clipboard, '__cloakbrowserPatchedWriteText', {
+                            value: true,
+                            configurable: true,
+                        });
+                    }
+                }
             """
             await context.add_init_script(_clipboard_init_js)
             # Also inject into already-open pages (about:blank created before init_script)

--- a/backend/browser_manager.py
+++ b/backend/browser_manager.py
@@ -12,11 +12,17 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import cloakbrowser.browser as cloakbrowser_browser
 from cloakbrowser import launch_persistent_context_async
 
 from .vnc_manager import VNCManager
 
 logger = logging.getLogger("cloakbrowser.manager.browser")
+
+# CloakBrowser's current Linux binary advertises HTTP proxy inline auth support,
+# but Chromium rejects `--proxy-server=http://user:pass@host:port` here with
+# net::ERR_NO_SUPPORTED_PROXIES. Force the Playwright proxy-auth path instead.
+cloakbrowser_browser._supports_http_proxy_inline_auth = lambda: False
 
 
 def _normalize_proxy(raw: str) -> str:

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,5 +1,3 @@
-"""SQLite database operations for browser profiles."""
-
 from __future__ import annotations
 
 import datetime
@@ -35,6 +33,7 @@ def init_db():
                 id TEXT PRIMARY KEY,
                 name TEXT NOT NULL,
                 fingerprint_seed INTEGER NOT NULL,
+                fingerprint_rotation_interval INTEGER DEFAULT 0,
                 proxy TEXT,
                 timezone TEXT,
                 locale TEXT,
@@ -67,17 +66,16 @@ def init_db():
         """)
         conn.commit()
 
-        # Migrations for existing databases
         cols = {row[1] for row in conn.execute("PRAGMA table_info(profiles)").fetchall()}
-        if "clipboard_sync" not in cols:
-            conn.execute("ALTER TABLE profiles ADD COLUMN clipboard_sync BOOLEAN DEFAULT 1")
-            conn.commit()
-        if "launch_args" not in cols:
-            conn.execute("ALTER TABLE profiles ADD COLUMN launch_args TEXT DEFAULT '[]'")
-            conn.commit()
-        if "auto_launch" not in cols:
-            conn.execute("ALTER TABLE profiles ADD COLUMN auto_launch BOOLEAN DEFAULT 0")
-            conn.commit()
+        for col, default in [
+            ("clipboard_sync", "1"),
+            ("launch_args", "'[]'"),
+            ("auto_launch", "0"),
+            ("fingerprint_rotation_interval", "0"),
+        ]:
+            if col not in cols:
+                conn.execute(f"ALTER TABLE profiles ADD COLUMN {col} INTEGER DEFAULT {default}")
+                conn.commit()
 
 
 def _now() -> str:
@@ -98,14 +96,16 @@ def create_profile(
     with get_db() as conn:
         conn.execute(
             """INSERT INTO profiles (
-                id, name, fingerprint_seed, proxy, timezone, locale, platform,
+                id, name, fingerprint_seed, fingerprint_rotation_interval,
+                proxy, timezone, locale, platform,
                 user_agent, screen_width, screen_height, gpu_vendor, gpu_renderer,
                 hardware_concurrency, humanize, human_preset, headless, geoip,
                 clipboard_sync, auto_launch, color_scheme, launch_args, notes,
                 user_data_dir, created_at, updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 profile_id, name, seed,
+                fields.get("fingerprint_rotation_interval", 0),
                 fields.get("proxy"),
                 fields.get("timezone"),
                 fields.get("locale"),
@@ -135,7 +135,7 @@ def create_profile(
             )
         conn.commit()
 
-    return get_profile(profile_id)  # type: ignore[return-value]
+    return get_profile(profile_id)
 
 
 def get_profile(profile_id: str) -> dict[str, Any] | None:
@@ -176,15 +176,14 @@ def update_profile(profile_id: str, **fields: Any) -> dict[str, Any] | None:
 
     tags = fields.pop("tags", None)
 
-    # Only update fields that were explicitly provided
     update_cols = []
     update_vals = []
-    # Pre-serialize launch_args to JSON before the generic update loop
     if "launch_args" in fields:
         fields["launch_args"] = json.dumps(fields["launch_args"] or [])
 
     for col in (
-        "name", "fingerprint_seed", "proxy", "timezone", "locale", "platform",
+        "name", "fingerprint_seed", "fingerprint_rotation_interval",
+        "proxy", "timezone", "locale", "platform",
         "user_agent", "screen_width", "screen_height", "gpu_vendor", "gpu_renderer",
         "hardware_concurrency", "humanize", "human_preset", "headless", "geoip",
         "clipboard_sync", "auto_launch", "color_scheme", "launch_args", "notes",

--- a/backend/main.py
+++ b/backend/main.py
@@ -630,14 +630,26 @@ async def get_clipboard(profile_id: str):
     if not running:
         raise HTTPException(status_code=404, detail="Profile not running")
 
-    # Read Chrome's current text selection via Playwright.
-    # Chrome's native copy (via VNC Ctrl+C) doesn't write to X11 clipboard
-    # and doesn't fire DOM events, so we read the visible selection instead.
-    # The init script also captures copy events when they do fire.
+    # Read Chrome's clipboard via Playwright/CDP when possible.
+    # If the page wrote to navigator.clipboard.writeText(), this sees the real
+    # browser clipboard even when there is no visible selection.
+    # The init script also captures copy events and patched writeText() calls.
     # Check all pages — user may have copied in any tab
     try:
         for page in running.context.pages:
             try:
+                text = await page.evaluate("""
+                    async () => {
+                        try {
+                            return await navigator.clipboard.readText();
+                        } catch {
+                            return '';
+                        }
+                    }
+                """)
+                if text:
+                    return {"text": text[:_CLIPBOARD_MAX_READ]}
+
                 text = await page.evaluate("window.__clipboardText || ''")
                 if text:
                     return {"text": text[:_CLIPBOARD_MAX_READ]}

--- a/backend/models.py
+++ b/backend/models.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field, field_validator
 class ProfileCreate(BaseModel):
     name: str
     fingerprint_seed: int | None = None  # random if not set
+    fingerprint_rotation_interval: int = 0  # minutes; 0 = disabled
     proxy: str | None = None  # "http://user:pass@host:port" or null
     timezone: str | None = None  # "America/New_York"
     locale: str | None = None  # "en-US"
@@ -35,6 +36,7 @@ class ProfileCreate(BaseModel):
 class ProfileUpdate(BaseModel):
     name: str | None = None
     fingerprint_seed: int | None = None
+    fingerprint_rotation_interval: int | None = None
     proxy: str | None = Field(default=None)
     timezone: str | None = Field(default=None)
     locale: str | None = Field(default=None)
@@ -71,6 +73,7 @@ class ProfileResponse(BaseModel):
     id: str
     name: str
     fingerprint_seed: int
+    fingerprint_rotation_interval: int = 0
     proxy: str | None = None
     timezone: str | None = None
     locale: str | None = None

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -296,7 +296,7 @@ def test_get_clipboard_from_page(app_client: TestClient):
 
     # Mock page with clipboard text
     mock_page = AsyncMock()
-    mock_page.evaluate = AsyncMock(return_value="copied text")
+    mock_page.evaluate = AsyncMock(side_effect=["", "copied text"])
 
     mock_context = MagicMock()
     mock_context.pages = [mock_page]
@@ -312,6 +312,31 @@ def test_get_clipboard_from_page(app_client: TestClient):
     assert resp.json()["text"] == "copied text"
 
     # Cleanup
+    main.browser_mgr.running.pop(pid, None)
+
+
+def test_get_clipboard_prefers_navigator_clipboard_read_text(app_client: TestClient):
+    """Copy buttons often call navigator.clipboard.writeText() without a selection."""
+    create = app_client.post("/api/profiles", json={"name": "ClipReadButton"})
+    pid = create.json()["id"]
+
+    mock_page = AsyncMock()
+    mock_page.evaluate = AsyncMock(side_effect=["button copied text"])
+
+    mock_context = MagicMock()
+    mock_context.pages = [mock_page]
+
+    mock_running = MagicMock(spec=RunningProfile)
+    mock_running.display = 100
+    mock_running.cdp_port = 5100
+    mock_running.context = mock_context
+    main.browser_mgr.running[pid] = mock_running
+
+    resp = app_client.get(f"/api/profiles/{pid}/clipboard")
+    assert resp.status_code == 200
+    assert resp.json()["text"] == "button copied text"
+    assert mock_page.evaluate.await_count == 1
+
     main.browser_mgr.running.pop(pid, None)
 
 

--- a/frontend/src/components/ProfileForm.tsx
+++ b/frontend/src/components/ProfileForm.tsx
@@ -1,9 +1,9 @@
-import { Save, Trash2, X } from "lucide-react";
+import { Save, Trash2, X, RefreshCw } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { Profile, ProfileCreateData } from "../lib/api";
 
 interface ProfileFormProps {
-  profile: Profile | null; // null = create mode
+  profile: Profile | null;
   onSave: (data: ProfileCreateData) => Promise<void>;
   onDelete?: () => Promise<void>;
   onCancel: () => void;
@@ -19,14 +19,14 @@ const RESOLUTION_PRESETS: Record<string, { width: number; height: number }> = {
 };
 
 const TAG_COLORS = [
-  "#6366f1", // indigo
-  "#22c55e", // green
-  "#f59e0b", // amber
-  "#ef4444", // red
-  "#06b6d4", // cyan
-  "#a855f7", // purple
-  "#f97316", // orange
-  "#ec4899", // pink
+  "#6366f1",
+  "#22c55e",
+  "#f59e0b",
+  "#ef4444",
+  "#06b6d4",
+  "#a855f7",
+  "#f97316",
+  "#ec4899",
 ];
 
 const GPU_PRESETS: Record<string, { vendor: string; renderer: string }> = {
@@ -66,6 +66,7 @@ export function ProfileForm({ profile, onSave, onDelete, onCancel }: ProfileForm
     geoip: false,
     clipboard_sync: true,
     auto_launch: false,
+    fingerprint_rotation_interval: 0,
     launch_args: [],
     tags: [],
   });
@@ -81,6 +82,7 @@ export function ProfileForm({ profile, onSave, onDelete, onCancel }: ProfileForm
       setForm({
         name: profile.name,
         fingerprint_seed: profile.fingerprint_seed,
+        fingerprint_rotation_interval: profile.fingerprint_rotation_interval,
         proxy: profile.proxy,
         timezone: profile.timezone,
         locale: profile.locale,
@@ -245,26 +247,20 @@ export function ProfileForm({ profile, onSave, onDelete, onCancel }: ProfileForm
                   title="Randomize seed"
                 >
                   <svg className="h-5 w-5" viewBox="0 0 32 32" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round">
-                    {/* Right face - lightest */}
                     <polygon points="28,10 16,16 16,28 28,22" fill="currentColor" opacity="0.06" />
                     <polygon points="28,10 16,16 16,28 28,22" />
-                    {/* Left face - medium shade */}
                     <polygon points="4,10 16,16 16,28 4,22" fill="currentColor" opacity="0.2" />
                     <polygon points="4,10 16,16 16,28 4,22" />
-                    {/* Top face - brightest */}
                     <polygon points="16,3 28,10 16,16 4,10" fill="currentColor" opacity="0.1" />
                     <polygon points="16,3 28,10 16,16 4,10" />
-                    {/* Dots on top face (3 - diagonal) */}
                     <circle cx="11.5" cy="8.5" r="1" fill="currentColor" opacity="0.7" />
                     <circle cx="16" cy="9.5" r="1" fill="currentColor" opacity="0.7" />
                     <circle cx="20.5" cy="10.5" r="1" fill="currentColor" opacity="0.7" />
-                    {/* Dots on left face (5 - dice pattern) */}
                     <circle cx="7.5" cy="14" r="0.9" fill="currentColor" opacity="0.6" />
                     <circle cx="12.5" cy="16.5" r="0.9" fill="currentColor" opacity="0.6" />
                     <circle cx="10" cy="19" r="0.9" fill="currentColor" opacity="0.6" />
                     <circle cx="7.5" cy="22" r="0.9" fill="currentColor" opacity="0.6" />
                     <circle cx="12.5" cy="24.5" r="0.9" fill="currentColor" opacity="0.6" />
-                    {/* Dots on right face (2 - diagonal) */}
                     <circle cx="20" cy="15" r="0.9" fill="currentColor" opacity="0.5" />
                     <circle cx="24" cy="20" r="0.9" fill="currentColor" opacity="0.5" />
                   </svg>
@@ -454,6 +450,27 @@ export function ProfileForm({ profile, onSave, onDelete, onCancel }: ProfileForm
               />
               Launch automatically when container starts
             </label>
+            <div>
+              <label className="label">
+                <div className="flex items-center gap-1.5">
+                  <RefreshCw className="h-3.5 w-3.5" />
+                  Fingerprint Rotation Interval (minutes)
+                </div>
+              </label>
+              <input
+                className="input"
+                type="number"
+                min="0"
+                value={form.fingerprint_rotation_interval ?? 0}
+                onChange={(e) => set("fingerprint_rotation_interval", Math.max(0, Number(e.target.value)))}
+                placeholder="0 = disabled"
+              />
+              <p className="text-xs text-gray-500 mt-1">
+                {form.fingerprint_rotation_interval && form.fingerprint_rotation_interval > 0
+                  ? `Browser will restart every ${form.fingerprint_rotation_interval} minute${form.fingerprint_rotation_interval > 1 ? 's' : ''} with a new random fingerprint`
+                  : "Set to 0 to keep a fixed fingerprint seed"}
+              </p>
+            </div>
             <div>
               <label className="label">Color Scheme</label>
               <select

--- a/frontend/src/components/ProfileViewer.tsx
+++ b/frontend/src/components/ProfileViewer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { ClipboardCopy, Code2, Maximize2, Minimize2 } from "lucide-react";
 import { api } from "../lib/api";
+import { copyText } from "../lib/clipboard";
 
 interface ProfileViewerProps {
   profileId: string;
@@ -253,8 +254,8 @@ export function ProfileViewer({ profileId, cdpUrl, clipboardSync: initialClipboa
           {cdpUrl && (
             <button
               onClick={() => {
-                const base = `${window.location.protocol}//${window.location.host}${cdpUrl}`;
-                navigator.clipboard?.writeText(base).then(() => {
+                const base = new URL(cdpUrl, window.location.origin).toString();
+                copyText(base).then(() => {
                   setCdpCopied(true);
                   setTimeout(() => setCdpCopied(false), 2000);
                 }).catch((err) => console.warn("[cdp] copy failed:", err));

--- a/frontend/src/components/ProfileViewer.tsx
+++ b/frontend/src/components/ProfileViewer.tsx
@@ -241,16 +241,16 @@ export function ProfileViewer({ profileId, cdpUrl, clipboardSync: initialClipboa
   }
 
   return (
-    <div className="relative h-full flex flex-col">
+    <div className="relative h-full flex flex-col overflow-hidden">
       {/* Toolbar */}
-      <div className="flex items-center justify-between px-3 py-1.5 bg-surface-1 border-b border-border">
+      <div className="relative z-20 shrink-0 flex items-center justify-between px-3 py-1.5 bg-surface-1 border-b border-border pointer-events-auto">
         <div className="flex items-center gap-2">
           <span className={`h-2 w-2 rounded-full ${connected ? "bg-emerald-400" : "bg-yellow-400 animate-pulse"}`} />
           <span className="text-xs text-gray-400">
             {connected ? "Connected" : "Connecting..."}
           </span>
         </div>
-        <div className="flex items-center gap-1">
+        <div className="relative z-20 flex items-center gap-1 pointer-events-auto">
           {cdpUrl && (
             <button
               onClick={() => {
@@ -287,7 +287,7 @@ export function ProfileViewer({ profileId, cdpUrl, clipboardSync: initialClipboa
       {/* VNC canvas container */}
       <div
         ref={containerRef}
-        className="flex-1 bg-black overflow-hidden"
+        className="relative z-0 flex-1 bg-black overflow-hidden"
         style={{ minHeight: 0 }}
       />
     </div>

--- a/frontend/src/components/ProfileViewer.tsx
+++ b/frontend/src/components/ProfileViewer.tsx
@@ -145,7 +145,7 @@ export function ProfileViewer({ profileId, cdpUrl, clipboardSync: initialClipboa
       const text = e.detail?.text;
       console.log("[clipboard] VNC→Host event fired, text:", text?.substring(0, 50), "len:", text?.length);
       if (text) {
-        navigator.clipboard.writeText(text).then(() => {
+        copyText(text).then(() => {
           console.log("[clipboard] writeText success");
         }).catch((err) => {
           console.warn("[clipboard] writeText failed:", err);
@@ -176,7 +176,7 @@ export function ProfileViewer({ profileId, cdpUrl, clipboardSync: initialClipboa
         if (text && text !== lastText) {
           lastText = text;
           console.log("[clipboard] poll: new VNC clipboard:", text.substring(0, 50), "len:", text.length);
-          await navigator.clipboard.writeText(text).catch((err) =>
+          await copyText(text).catch((err) =>
             console.warn("[clipboard] poll writeText failed:", err)
           );
         }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,6 +6,7 @@ export interface Profile {
   id: string;
   name: string;
   fingerprint_seed: number;
+  fingerprint_rotation_interval: number;
   proxy: string | null;
   timezone: string | null;
   locale: string | null;
@@ -37,6 +38,7 @@ export interface Profile {
 export interface ProfileCreateData {
   name: string;
   fingerprint_seed?: number | null;
+  fingerprint_rotation_interval?: number;
   proxy?: string | null;
   timezone?: string | null;
   locale?: string | null;
@@ -82,7 +84,6 @@ class ApiError extends Error {
   }
 }
 
-// Global 401 callback — set by App to trigger login page on auth failure
 let _onUnauthorized: (() => void) | null = null;
 export function setOnUnauthorized(cb: (() => void) | null) {
   _onUnauthorized = cb;

--- a/frontend/src/lib/clipboard.test.ts
+++ b/frontend/src/lib/clipboard.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { copyText } from "./clipboard";
+
+describe("copyText", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("uses navigator.clipboard.writeText when available", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    await copyText("ws://example.test/cdp");
+
+    expect(writeText).toHaveBeenCalledWith("ws://example.test/cdp");
+  });
+
+  it("falls back to execCommand when clipboard API rejects", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("insecure context"));
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    const execCommand = vi.fn().mockReturnValue(true);
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    await copyText("http://100.90.93.80:8082/api/profiles/123/cdp");
+
+    expect(writeText).toHaveBeenCalled();
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("falls back to execCommand when clipboard API is unavailable", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+
+    const execCommand = vi.fn().mockReturnValue(true);
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    await copyText("plain text");
+
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+});

--- a/frontend/src/lib/clipboard.ts
+++ b/frontend/src/lib/clipboard.ts
@@ -1,0 +1,35 @@
+export async function copyText(text: string): Promise<void> {
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch {
+      // Fallback below for insecure origins like http://<tailscale-ip>
+    }
+  }
+
+  if (typeof document === "undefined") {
+    throw new Error("Clipboard unavailable");
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.top = "0";
+  textarea.style.left = "0";
+  textarea.style.opacity = "0";
+  textarea.style.pointerEvents = "none";
+
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  textarea.setSelectionRange(0, textarea.value.length);
+
+  const ok = document.execCommand("copy");
+  document.body.removeChild(textarea);
+
+  if (!ok) {
+    throw new Error("Clipboard copy failed");
+  }
+}

--- a/ops/watchdog/README.md
+++ b/ops/watchdog/README.md
@@ -1,0 +1,45 @@
+# CloakBrowser host watchdog
+
+## Problem
+
+`auto_launch=true` only launches profiles when the manager process starts.
+If the manager stays alive but an individual browser/profile crashes and flips
+back to `stopped`, the built-in startup auto-launch does not bring it back.
+
+## What this adds
+
+- `cloakbrowser_watchdog.py` polls the manager API
+- any profile with `auto_launch=true` and `status != running` gets relaunched
+- intended for host-level `systemd` supervision
+
+## Install
+
+Assume your repo checkout lives at `/opt/cloakbrowser-manager` and the manager
+API is reachable at `http://127.0.0.1:8080`.
+
+```bash
+sudo cp ops/watchdog/cloakbrowser-watchdog.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now cloakbrowser-watchdog.service
+```
+
+## Verify
+
+```bash
+systemctl status cloakbrowser-watchdog.service --no-pager
+journalctl -u cloakbrowser-watchdog.service -n 50 --no-pager
+curl http://127.0.0.1:8080/api/profiles
+```
+
+Smoke test:
+- create a profile
+- set `auto_launch=true`
+- wait for watchdog to launch it
+- stop the profile manually
+- verify watchdog launches it again within ~15s
+
+## Caveat
+
+If you intentionally want a profile to stay down, turn `auto_launch=false`
+first. Otherwise the watchdog will treat a manual stop the same as a crash and
+bring it back.

--- a/ops/watchdog/cloakbrowser-watchdog.service
+++ b/ops/watchdog/cloakbrowser-watchdog.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=CloakBrowser profile auto-heal watchdog
+After=docker.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/cloakbrowser-manager
+ExecStart=/usr/bin/python3 /opt/cloakbrowser-manager/ops/watchdog/cloakbrowser_watchdog.py
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/watchdog/cloakbrowser_watchdog.py
+++ b/ops/watchdog/cloakbrowser_watchdog.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Host-side watchdog for CloakBrowser Manager.
+
+Polls the manager API and re-launches any profile that has auto_launch=true
+but is currently stopped. This closes the gap where the built-in auto-launch
+only runs during manager startup.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+
+BASE_URL = "http://127.0.0.1:8080"
+POLL_SECONDS = 15
+REQUEST_TIMEOUT = 10
+AUTO_LAUNCH_ONLY = True
+
+
+def http_json(method: str, path: str, payload: dict[str, Any] | None = None) -> Any:
+    data = None
+    headers: dict[str, str] = {}
+    if payload is not None:
+        data = json.dumps(payload).encode()
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(BASE_URL + path, data=data, headers=headers, method=method)
+    with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
+        raw = resp.read().decode("utf-8")
+        return json.loads(raw) if raw else None
+
+
+def manager_up() -> bool:
+    try:
+        data = http_json("GET", "/api/status")
+        return isinstance(data, dict) and "profiles_total" in data
+    except Exception:
+        return False
+
+
+def loop_forever() -> None:
+    print(f"[watchdog] starting base_url={BASE_URL} poll={POLL_SECONDS}s", flush=True)
+    consecutive_failures = 0
+    while True:
+        try:
+            if not manager_up():
+                consecutive_failures += 1
+                print(f"[watchdog] manager not ready (failures={consecutive_failures})", flush=True)
+                time.sleep(POLL_SECONDS)
+                continue
+
+            profiles = http_json("GET", "/api/profiles") or []
+            consecutive_failures = 0
+            relaunched = 0
+            for profile in profiles:
+                profile_id = profile.get("id")
+                name = profile.get("name")
+                status = profile.get("status")
+                auto_launch = bool(profile.get("auto_launch"))
+
+                if AUTO_LAUNCH_ONLY and not auto_launch:
+                    continue
+                if status == "running":
+                    continue
+
+                print(
+                    f"[watchdog] relaunching profile name={name} id={profile_id} "
+                    f"status={status} auto_launch={auto_launch}",
+                    flush=True,
+                )
+                try:
+                    result = http_json("POST", f"/api/profiles/{profile_id}/launch")
+                    relaunched += 1
+                    print(
+                        f"[watchdog] relaunched name={name} id={profile_id} result={result}",
+                        flush=True,
+                    )
+                except urllib.error.HTTPError as exc:
+                    body = exc.read().decode("utf-8", errors="replace")
+                    print(
+                        f"[watchdog] HTTPError relaunching name={name} id={profile_id}: "
+                        f"{exc.code} {body}",
+                        flush=True,
+                    )
+                except Exception as exc:
+                    print(
+                        f"[watchdog] error relaunching name={name} id={profile_id}: {exc}",
+                        flush=True,
+                    )
+
+            if relaunched == 0:
+                print(f"[watchdog] healthy: checked {len(profiles)} profiles; nothing to relaunch", flush=True)
+        except Exception as exc:
+            consecutive_failures += 1
+            print(f"[watchdog] loop error failures={consecutive_failures}: {exc}", flush=True)
+
+        time.sleep(POLL_SECONDS)
+
+
+if __name__ == "__main__":
+    try:
+        loop_forever()
+    except KeyboardInterrupt:
+        print("[watchdog] stopped", flush=True)
+        sys.exit(0)


### PR DESCRIPTION
## Summary
- adds a host-side watchdog to automatically relaunch CloakBrowser profiles when the browser/profile crashes while the manager process is still alive
- closes the current operational gap: upstream `auto_launch=true` only applies at manager startup and does not continuously self-heal afterward
- keeps the PR low-risk and easy to review: this adds `ops/watchdog/` examples and runbook guidance without changing the upstream core runtime

## Root cause → fix
- Root cause: built-in auto-launch only handles the initial manager startup path
  - Fix: add a watchdog that polls `/api/profiles` and calls `POST /api/profiles/<id>/launch` for profiles with `auto_launch=true` but `status != running`
- Root cause: there is no standard host-side runbook for enabling auto-heal behavior
  - Fix: add a sample `systemd` unit plus install/verification/smoke-test documentation

## Flow
```mermaid
flowchart TD
    A[cloakbrowser-manager healthy] --> B[profile or browser crashes]
    B --> C[profile status becomes stopped]
    C --> D[host watchdog polls /api/profiles every 15s]
    D --> E{auto_launch = true?}
    E -- no --> F[leave profile stopped]
    E -- yes --> G[POST /api/profiles/<id>/launch]
    G --> H[profile returns to running]
```

## Before / After
- Before:
  - the manager container can remain healthy
  - a crashed profile stays in `stopped`
  - an operator must relaunch it manually
- After:
  - the manager container can remain healthy
  - the watchdog detects the `stopped` profile
  - any profile with `auto_launch=true` is relaunched automatically within about 15 seconds

## Files changed
- `README.md`
  - adds a section describing the custom fork behavior and operating caveat
- `ops/watchdog/cloakbrowser_watchdog.py`
  - adds a host-side Python watchdog that polls the manager API and relaunches eligible profiles
- `ops/watchdog/cloakbrowser-watchdog.service`
  - adds a sample `systemd` service for durable host-side execution
- `ops/watchdog/README.md`
  - adds install, verification, smoke-test, and manual-stop caveat documentation

## Scope
- ✅ adds auto-heal behavior at the host/operator layer
- ✅ preserves upstream behavior for users who do not enable the watchdog
- ✅ documents the `auto_launch=false` caveat for intentionally keeping a profile down
- ❌ does not yet make the watchdog a built-in core manager feature
- ❌ does not yet add a dedicated UI override for intentional manual-stop persistence

## Evidence
- verified against the real runtime on Dogo `it-workstation-2` with a smoke test:
  - created a test profile
  - set `auto_launch=true`
  - waited for the watchdog launch -> `running`
  - stopped it manually
  - waited for the watchdog relaunch -> `running`
- real logs confirmed the expected pattern:
  - `relaunching profile ... status=stopped auto_launch=True`
  - `relaunched profile ... status=running`

## Notes
- if an operator wants a profile to stay down, they should set `auto_launch=false` first
- otherwise the watchdog treats a manual stop the same way it treats a crash and will bring the profile back up