### PR TITLE
fix: constrain browser window to VNC framebuffer

### DIFF
--- a/backend/browser_manager.py
+++ b/backend/browser_manager.py
@@ -233,6 +233,12 @@ class BrowserManager:
                 env={**os.environ, "DISPLAY": f":{display}"},
             )
 
+            await self._fit_window_to_vnc(
+                context,
+                width=profile.get("screen_width", 1920),
+                height=profile.get("screen_height", 1080),
+            )
+
             # Inject clipboard listener: captures copied text on every page
             # so the GET /clipboard endpoint can read it via page.evaluate()
             _clipboard_init_js = """
@@ -338,6 +344,45 @@ class BrowserManager:
     async def cleanup_stale(self):
         """Kill orphan processes from previous container runs."""
         await self.vnc.cleanup_stale()
+
+    async def _fit_window_to_vnc(self, context: Any, width: int, height: int) -> None:
+        """Keep the native browser window inside the VNC framebuffer."""
+        if not getattr(context, "pages", None):
+            logger.debug("Skipping VNC window fit: no pages available")
+            return
+
+        try:
+            session = await context.new_cdp_session(context.pages[0])
+            result = await session.send("Browser.getWindowForTarget")
+            bounds = result.get("bounds", {})
+            left = int(bounds.get("left", 0))
+            top = int(bounds.get("top", 0))
+            current_width = int(bounds.get("width", width))
+            current_height = int(bounds.get("height", height))
+
+            overflows = (
+                left != 0
+                or top != 0
+                or left + current_width > width
+                or top + current_height > height
+            )
+            if not overflows:
+                return
+
+            await session.send(
+                "Browser.setWindowBounds",
+                {
+                    "windowId": result["windowId"],
+                    "bounds": {"left": 0, "top": 0, "width": width, "height": height},
+                },
+            )
+            logger.info(
+                "Adjusted browser window to fit VNC framebuffer %dx%d",
+                width,
+                height,
+            )
+        except Exception as exc:
+            logger.warning("Failed to adjust browser window bounds: %s", exc)
 
     async def auto_launch_all(self):
         """Launch all profiles with auto_launch=True. Called on startup."""

--- a/backend/tests/test_browser_manager.py
+++ b/backend/tests/test_browser_manager.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 import socket
+from unittest.mock import AsyncMock, MagicMock
 
 from backend.browser_manager import (
     BASE_CDP_PORT,
@@ -174,6 +175,55 @@ def test_launch_args_none_no_effect():
     base_count = len(args)
     args += profile.get("launch_args") or []
     assert len(args) == base_count
+
+
+# ── VNC browser window bounds ─────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_fit_window_to_vnc_moves_oversized_window_back_inside_framebuffer():
+    mgr = BrowserManager()
+    page = MagicMock()
+    session = MagicMock()
+    session.send = AsyncMock(
+        side_effect=[
+            {
+                "windowId": 123,
+                "bounds": {
+                    "left": 10,
+                    "top": 10,
+                    "width": 1928,
+                    "height": 1078,
+                    "windowState": "normal",
+                },
+            },
+            {
+                "windowId": 123,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "width": 1919,
+                    "height": 1079,
+                    "windowState": "normal",
+                },
+            },
+        ]
+    )
+    context = MagicMock()
+    context.pages = [page]
+    context.new_cdp_session = AsyncMock(return_value=session)
+
+    await mgr._fit_window_to_vnc(context, width=1920, height=1080)
+
+    context.new_cdp_session.assert_awaited_once_with(page)
+    session.send.assert_any_await("Browser.getWindowForTarget")
+    session.send.assert_any_await(
+        "Browser.setWindowBounds",
+        {
+            "windowId": 123,
+            "bounds": {"left": 0, "top": 0, "width": 1920, "height": 1080},
+        },
+    )
 
 
 # ── _allocate_cdp_port ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary\n- resize and reposition the native browser window when it overflows the VNC framebuffer\n- use the profile screen size as the framebuffer boundary\n- add a regression test for oversized/offscreen window bounds\n\n## Tests\n- pytest backend/tests/test_browser_manager.py -k fit_window_to_vnc\n\n## Notes\n- This PR intentionally excludes local Dockerfile mirror changes from my deployment environment.