### PR TITLE
fix: require auth for /api/status, add unauthenticated /api/health probe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN python -c "from cloakbrowser.download import ensure_binary; ensure_binary()"
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/api/status')" || exit 1
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/api/health')" || exit 1
 
 VOLUME /data
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ When `AUTH_TOKEN` is set:
 - The web UI shows a login page. Enter the token to unlock.
 - API consumers pass the token via `Authorization: Bearer <token>` header.
 - VNC WebSocket connections are authenticated via the login cookie.
-- The `/api/status` endpoint remains unauthenticated (for Docker healthcheck).
+- The `/api/health` endpoint remains unauthenticated (for Docker healthcheck); it exposes no system details. The `/api/status` endpoint (running counts, version) now requires authentication.
 
 > **Note**: The auth token is transmitted in cleartext over HTTP. If you expose the Manager to the internet, put it behind a reverse proxy with HTTPS (Caddy, nginx, Traefik).
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -47,11 +47,12 @@ logging.getLogger("asyncio").setLevel(logging.WARNING)
 
 # Optional authentication via AUTH_TOKEN env var.
 # If not set, all routes are open (local dev). If set, all /api/* routes
-# (except /api/auth/* and /api/status) require Bearer token or cookie.
+# (except /api/auth/status, /api/auth/login and /api/health) require Bearer
+# token or cookie.
 AUTH_TOKEN: str | None = os.environ.get("AUTH_TOKEN") or None
 
 # Paths that bypass authentication even when AUTH_TOKEN is set
-_AUTH_EXEMPT = frozenset({"/api/auth/status", "/api/auth/login", "/api/status"})
+_AUTH_EXEMPT = frozenset({"/api/auth/status", "/api/auth/login", "/api/health"})
 
 
 def _check_auth(scope: Scope) -> bool:
@@ -565,6 +566,16 @@ async def get_profile_status(profile_id: str):
 
 
 # ── System Status ─────────────────────────────────────────────────────────────
+
+
+@app.get("/api/health")
+async def health_check():
+    """Unauthenticated liveness probe for the Docker healthcheck.
+
+    Intentionally returns no system details; see /api/status (auth-gated)
+    for running counts and versions.
+    """
+    return {"status": "ok"}
 
 
 @app.get("/api/status", response_model=StatusResponse)

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -128,8 +128,18 @@ def test_logout_clears_cookie(client_auth: TestClient):
 
 
 def test_healthcheck_always_accessible(client_auth: TestClient):
-    """GET /api/status must work without auth (Docker healthcheck)."""
+    """GET /api/health must work without auth (Docker healthcheck)."""
+    resp = client_auth.get("/api/health")
+    assert resp.status_code == 200
+
+
+def test_status_requires_auth(client_auth: TestClient):
+    """GET /api/status must require auth (leaks profile count and version)."""
     resp = client_auth.get("/api/status")
+    assert resp.status_code == 401
+    resp = client_auth.get(
+        "/api/status", headers={"Authorization": "Bearer test-secret"}
+    )
     assert resp.status_code == 200
 
 


### PR DESCRIPTION
## Problem

`/api/status` is in the auth-exempt set so the Docker healthcheck can reach it. But with `AUTH_TOKEN` set, it still returns `running_count`, `binary_version` and `profiles_total` **without authentication**. This is an information-disclosure endpoint that scanners (e.g. fofa) use to fingerprint exposed Manager instances and learn how many profiles exist.

## Change

- Add a dedicated `GET /api/health` probe that returns only `{"status": "ok"}` with no system details, and keep it auth-exempt.
- Remove `/api/status` from the exempt set, so it now requires the token like `/api/profiles`.
- Point the Dockerfile `HEALTHCHECK` at `/api/health`.
- Update the README auth section and tests.

## Tests

- `test_healthcheck_always_accessible` now probes `/api/health`.
- New `test_status_requires_auth`: `/api/status` returns 401 without a token and 200 with the correct Bearer token.
- Full `test_auth.py` + `test_api.py` suite passes (60 passed).

No frontend impact: the dashboard determines auth state via `/api/auth/status`, and `getStatus()` (which calls `/api/status`) runs only inside the authenticated app.