### PR TITLE
Add native macOS profile launching

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,29 @@ docker compose up --build
 
 Open [http://localhost:8080](http://localhost:8080) in your browser. Create a profile. Click Launch. Done.
 
+### Native macOS profiles
+
+Run Manager directly on macOS to launch existing local CloakBrowser profiles in
+normal app windows. Set `DATA_DIR` for Manager state and optionally
+`NATIVE_PROFILE_REGISTRY` to a JSON registry. Default registry:
+`~/.cloakbrowser/manager/native-profiles.json`.
+
+```json
+[
+  {
+    "native_profile": "google-001",
+    "name": "GOOGLE 1",
+    "start_urls": ["https://accounts.google.com/"],
+    "notes": "Account metadata only. Never store secrets here.",
+    "tags": [{"tag": "native-macos"}, {"tag": "google"}]
+  }
+]
+```
+
+Native profiles launch through `~/.local/bin/cloak-bitwarden-profile`. Override
+that path with `NATIVE_CLOAK_LAUNCHER`. Chromium data remains under
+`~/.cloakbrowser/profiles`; Manager never copies it into Git or `/data`.
+
 > **Early alpha** — this project is under active development. Expect bugs. If you find one, please [open an issue](https://github.com/CloakHQ/CloakBrowser-Manager/issues).
 
 ## Why Not Just Use a VPN?
@@ -119,6 +142,28 @@ Your profiles and session data are stored in the `cloakprofiles` volume and pers
 ## Automation API
 
 Every running profile exposes a CDP (Chrome DevTools Protocol) endpoint. Connect Playwright or Puppeteer to automate a profile while watching it live in the browser.
+
+**Recommended agent path:** use Manager as source of truth. Agent finds profile,
+launches it through Manager, then connects through Manager CDP. Do not open the
+profile directory directly from agent code. This preserves profile locking,
+Bitwarden sync, network policy, and UI status.
+
+```text
+Browser agent -> Manager API -> native launcher -> CloakBrowser profile
+              -> Manager CDP -> same live browser window
+```
+
+Ready-to-copy Python client: `examples/browser_agent.py`.
+
+```bash
+pip install httpx playwright
+CLOAK_MANAGER_URL=http://127.0.0.1:8081 \
+  python examples/browser_agent.py
+```
+
+Change `connect("google-002")` to any `native_profile` value from the local
+registry. For reusable agents, call `connect()` and work with returned
+Playwright context. Manager UI and agent always control the same session.
 
 ```python
 from playwright.async_api import async_playwright

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ normal app windows. Set `DATA_DIR` for Manager state and optionally
     "native_profile": "google-001",
     "name": "GOOGLE 1",
     "start_urls": ["https://accounts.google.com/"],
-    "notes": "Account metadata only. Never store secrets here.",
+    "notes": "Account and session notes for this profile.",
     "tags": [{"tag": "native-macos"}, {"tag": "google"}]
   }
 ]

--- a/backend/browser_manager.py
+++ b/backend/browser_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -11,8 +12,6 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-
-from cloakbrowser import launch_persistent_context_async
 
 from .vnc_manager import VNCManager
 
@@ -149,10 +148,12 @@ CDP_PORT_RANGE = 100  # cycle through 5100-5199 to avoid TIME_WAIT collisions
 @dataclass
 class RunningProfile:
     profile_id: str
-    context: Any  # Playwright BrowserContext
-    display: int
-    ws_port: int
+    context: Any | None
+    display: int | None
+    ws_port: int | None
     cdp_port: int
+    process: asyncio.subprocess.Process | None = None
+    native: bool = False
 
 
 class BrowserManager:
@@ -172,6 +173,17 @@ class BrowserManager:
             if profile_id in self.running or profile_id in self._launching:
                 raise RuntimeError(f"Profile {profile_id} is already running")
             self._launching.add(profile_id)
+
+        native_profile = self._native_profile_name(profile)
+        if native_profile:
+            return await self._launch_native(profile_id, native_profile, self._start_urls(profile))
+
+        try:
+            from cloakbrowser import launch_persistent_context_async
+        except BaseException:
+            async with self._lock:
+                self._launching.discard(profile_id)
+            raise
 
         display, ws_port = await self.vnc.allocate()
 
@@ -203,7 +215,10 @@ class BrowserManager:
 
             # Build fingerprint args from profile settings
             extra_args = self._build_fingerprint_args(profile)
-            extra_args += profile.get("launch_args") or []
+            extra_args += [
+                arg for arg in profile.get("launch_args") or []
+                if not arg.startswith(("--native-profile=", "--start-url="))
+            ]
             extra_args.append(f"--remote-debugging-port={cdp_port}")
 
             # Normalize proxy format (host:port:user:pass → http://user:pass@host:port)
@@ -286,6 +301,100 @@ class BrowserManager:
             await self.vnc.stop_vnc(display)
             raise
 
+    @staticmethod
+    def _native_profile_name(profile: dict[str, Any]) -> str | None:
+        for arg in profile.get("launch_args") or []:
+            if arg.startswith("--native-profile="):
+                return arg.partition("=")[2] or None
+        return None
+
+    @staticmethod
+    def _start_urls(profile: dict[str, Any]) -> list[str]:
+        return [
+            arg.partition("=")[2]
+            for arg in profile.get("launch_args") or []
+            if arg.startswith("--start-url=") and arg.partition("=")[2]
+        ]
+
+    @staticmethod
+    def _native_cdp_port(profile_name: str) -> int:
+        digest = hashlib.sha256(profile_name.encode()).digest()
+        return 9400 + (int.from_bytes(digest[:2], "big") % 400)
+
+    async def _launch_native(
+        self,
+        profile_id: str,
+        profile_name: str,
+        start_urls: list[str],
+    ) -> RunningProfile:
+        launcher = os.getenv(
+            "NATIVE_CLOAK_LAUNCHER",
+            str(Path.home() / ".local/bin/cloak-bitwarden-profile"),
+        )
+        cdp_port = self._native_cdp_port(profile_name)
+
+        try:
+            process = await asyncio.create_subprocess_exec(
+                launcher,
+                "open",
+                profile_name,
+                *start_urls,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            await self._wait_for_port(cdp_port, process)
+            running = RunningProfile(
+                profile_id=profile_id,
+                context=None,
+                display=None,
+                ws_port=None,
+                cdp_port=cdp_port,
+                process=process,
+                native=True,
+            )
+            async with self._lock:
+                self.running[profile_id] = running
+                self._launching.discard(profile_id)
+            asyncio.create_task(self._watch_native(profile_id, process))
+            logger.info("Launched native profile %s on CDP port %d", profile_name, cdp_port)
+            return running
+        except BaseException:
+            async with self._lock:
+                self._launching.discard(profile_id)
+            raise
+
+    @staticmethod
+    async def _wait_for_port(
+        port: int,
+        process: asyncio.subprocess.Process,
+        timeout: float = 45,
+    ) -> None:
+        deadline = asyncio.get_running_loop().time() + timeout
+        while asyncio.get_running_loop().time() < deadline:
+            if process.returncode is not None:
+                error = await process.stderr.read() if process.stderr else b""
+                raise RuntimeError(error.decode().strip() or "Native launcher exited")
+            try:
+                _, writer = await asyncio.open_connection("127.0.0.1", port)
+                writer.close()
+                await writer.wait_closed()
+                return
+            except OSError:
+                await asyncio.sleep(0.25)
+        process.terminate()
+        raise TimeoutError(f"Native profile CDP port {port} did not open")
+
+    async def _watch_native(
+        self,
+        profile_id: str,
+        process: asyncio.subprocess.Process,
+    ) -> None:
+        await process.wait()
+        async with self._lock:
+            current = self.running.get(profile_id)
+            if current and current.process is process:
+                self.running.pop(profile_id, None)
+
     async def _on_browser_closed(self, profile_id: str):
         """Called when browser exits (crash, user closed via VNC, or stop())."""
         async with self._lock:
@@ -293,7 +402,8 @@ class BrowserManager:
 
         if running:
             logger.info("Browser closed for profile %s, cleaning up", profile_id)
-            await self.vnc.stop_vnc(running.display)
+            if running.display is not None:
+                await self.vnc.stop_vnc(running.display)
 
     async def stop(self, profile_id: str):
         """Stop a running browser instance."""
@@ -306,12 +416,23 @@ class BrowserManager:
 
         logger.info("Stopping profile %s", profile_id)
 
-        try:
-            await running.context.close()
-        except Exception as exc:
-            logger.warning("Error closing context for %s: %s", profile_id, exc)
+        if running.native and running.process:
+            running.process.terminate()
+            try:
+                await asyncio.wait_for(running.process.wait(), timeout=10)
+            except TimeoutError:
+                running.process.kill()
+                await running.process.wait()
+            return
 
-        await self.vnc.stop_vnc(running.display)
+        if running.context:
+            try:
+                await running.context.close()
+            except Exception as exc:
+                logger.warning("Error closing context for %s: %s", profile_id, exc)
+
+        if running.display is not None:
+            await self.vnc.stop_vnc(running.display)
 
     def get_status(self, profile_id: str) -> dict[str, Any]:
         """Get running status for a profile."""
@@ -320,7 +441,7 @@ class BrowserManager:
             return {
                 "status": "running",
                 "vnc_ws_port": running.ws_port,
-                "display": f":{running.display}",
+                "display": "native-macos" if running.native else f":{running.display}",
                 "cdp_url": f"/api/profiles/{profile_id}/cdp",
             }
         return {"status": "stopped", "vnc_ws_port": None, "display": None, "cdp_url": None}

--- a/backend/database.py
+++ b/backend/database.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime
 import json
+import os
 import random
 import sqlite3
 import uuid
@@ -11,7 +12,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
-DATA_DIR = Path("/data")
+DATA_DIR = Path(os.getenv("DATA_DIR", "/data"))
 DB_PATH = DATA_DIR / "profiles.db"
 
 
@@ -167,6 +168,44 @@ def list_profiles() -> list[dict[str, Any]]:
             profile["tags"] = [dict(t) for t in tags]
             profiles.append(profile)
         return profiles
+
+
+def sync_native_profiles(path: Path | None = None) -> int:
+    """Create or update native profiles from a local, non-secret registry."""
+    path = path or Path(os.getenv(
+        "NATIVE_PROFILE_REGISTRY",
+        str(DATA_DIR / "native-profiles.json"),
+    ))
+    if not path.exists():
+        return 0
+
+    entries = json.loads(path.read_text())
+    existing = list_profiles()
+    by_native_name = {
+        arg.partition("=")[2]: profile
+        for profile in existing
+        for arg in profile.get("launch_args") or []
+        if arg.startswith("--native-profile=")
+    }
+
+    for entry in entries:
+        native_name = entry["native_profile"]
+        fields = {
+            "launch_args": [
+                f"--native-profile={native_name}",
+                *[f"--start-url={url}" for url in entry.get("start_urls", [])],
+            ],
+            "notes": entry.get("notes"),
+            "tags": entry.get("tags", []),
+            "platform": "macos",
+            "clipboard_sync": False,
+        }
+        current = by_native_name.get(native_name)
+        if current:
+            update_profile(current["id"], name=entry["name"], **fields)
+        else:
+            create_profile(name=entry["name"], **fields)
+    return len(entries)
 
 
 def update_profile(profile_id: str, **fields: Any) -> dict[str, Any] | None:

--- a/backend/main.py
+++ b/backend/main.py
@@ -375,6 +375,9 @@ def _filter_rfb_client_messages(data: bytes) -> bytes:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     db.init_db()
+    synced = db.sync_native_profiles()
+    if synced:
+        logger.info("Synced %d native profiles", synced)
     await browser_mgr.cleanup_stale()
     browser_mgr._auto_launch_task = asyncio.create_task(browser_mgr.auto_launch_all())
     logger.info("CloakBrowser Manager started")
@@ -542,7 +545,7 @@ async def launch_profile(profile_id: str):
         profile_id=profile_id,
         status="running",
         vnc_ws_port=running.ws_port,
-        display=f":{running.display}",
+        display="native-macos" if running.native else f":{running.display}",
         cdp_url=f"/api/profiles/{profile_id}/cdp",
     )
 
@@ -569,7 +572,10 @@ async def get_profile_status(profile_id: str):
 
 @app.get("/api/status", response_model=StatusResponse)
 async def get_system_status():
-    from cloakbrowser.config import CHROMIUM_VERSION
+    try:
+        from cloakbrowser.config import CHROMIUM_VERSION
+    except ModuleNotFoundError:
+        CHROMIUM_VERSION = "native-launcher"
 
     profiles = db.list_profiles()
     return StatusResponse(
@@ -683,6 +689,9 @@ async def vnc_proxy(websocket: WebSocket, profile_id: str):
     running = browser_mgr.running.get(profile_id)
     if not running:
         await websocket.close(code=4004, reason="Profile not running")
+        return
+    if running.ws_port is None:
+        await websocket.close(code=4004, reason="Native profile has no VNC session")
         return
 
     # Accept with client's requested subprotocol (if any) — RFC 6455 requires

--- a/backend/models.py
+++ b/backend/models.py
@@ -108,8 +108,8 @@ class ProfileResponse(BaseModel):
 class LaunchResponse(BaseModel):
     profile_id: str
     status: str = "running"
-    vnc_ws_port: int
-    display: str
+    vnc_ws_port: int | None
+    display: str | None
     cdp_url: str | None = None
 
 

--- a/backend/tests/test_browser_manager.py
+++ b/backend/tests/test_browser_manager.py
@@ -228,6 +228,30 @@ def test_allocate_cdp_port_all_occupied_raises():
             s.close()
 
 
+def test_native_profile_name():
+    profile = {"launch_args": ["--native-profile=google-001"]}
+    assert _mgr._native_profile_name(profile) == "google-001"
+
+
+def test_native_profile_name_missing():
+    assert _mgr._native_profile_name({"launch_args": []}) is None
+
+
+def test_start_urls():
+    profile = {
+        "launch_args": [
+            "--native-profile=google-002",
+            "--start-url=https://accounts.google.com/",
+        ]
+    }
+    assert _mgr._start_urls(profile) == ["https://accounts.google.com/"]
+
+
+def test_native_cdp_ports_match_launcher():
+    assert _mgr._native_cdp_port("google-001") == 9558
+    assert _mgr._native_cdp_port("google-002") == 9684
+
+
 # ── _init_profile_defaults ───────────────────────────────────────────────────
 
 

--- a/backend/tests/test_native_profile_registry.py
+++ b/backend/tests/test_native_profile_registry.py
@@ -1,0 +1,31 @@
+import json
+
+from backend import database as db
+
+
+def test_sync_native_profiles_creates_and_updates(tmp_db, tmp_path):
+    registry = tmp_path / "native-profiles.json"
+    registry.write_text(json.dumps([{
+        "native_profile": "google-001",
+        "name": "GOOGLE 1",
+        "start_urls": ["https://accounts.google.com/"],
+        "notes": "First",
+        "tags": [{"tag": "google"}],
+    }]))
+
+    assert db.sync_native_profiles(registry) == 1
+    profile = db.list_profiles()[0]
+    assert profile["name"] == "GOOGLE 1"
+    assert profile["launch_args"] == [
+        "--native-profile=google-001",
+        "--start-url=https://accounts.google.com/",
+    ]
+
+    data = json.loads(registry.read_text())
+    data[0]["name"] = "GOOGLE 1 — Updated"
+    registry.write_text(json.dumps(data))
+    db.sync_native_profiles(registry)
+
+    profiles = db.list_profiles()
+    assert len(profiles) == 1
+    assert profiles[0]["name"] == "GOOGLE 1 — Updated"

--- a/examples/browser_agent.py
+++ b/examples/browser_agent.py
@@ -1,0 +1,41 @@
+"""Small reference client for controlling a Manager profile with Playwright."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import httpx
+from playwright.async_api import async_playwright
+
+MANAGER_URL = os.getenv("CLOAK_MANAGER_URL", "http://127.0.0.1:8080")
+
+
+async def connect(native_profile: str):
+    async with httpx.AsyncClient(base_url=MANAGER_URL) as client:
+        profiles = (await client.get("/api/profiles")).raise_for_status().json()
+        marker = f"--native-profile={native_profile}"
+        profile = next(p for p in profiles if marker in p["launch_args"])
+        if profile["status"] != "running":
+            (await client.post(f"/api/profiles/{profile['id']}/launch")).raise_for_status()
+
+    playwright = await async_playwright().start()
+    browser = await playwright.chromium.connect_over_cdp(
+        f"{MANAGER_URL}/api/profiles/{profile['id']}/cdp"
+    )
+    return playwright, browser, browser.contexts[0]
+
+
+async def main():
+    playwright, browser, context = await connect("google-002")
+    try:
+        page = context.pages[-1] if context.pages else await context.new_page()
+        await page.goto("https://accounts.google.com/", wait_until="domcontentloaded")
+        print(await page.title())
+    finally:
+        # Disconnect agent only. Manager owns browser lifecycle.
+        await playwright.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { api, setOnUnauthorized, type ProfileCreateData } from "./lib/api";
 import { ProfileList } from "./components/ProfileList";
 import { ProfileForm } from "./components/ProfileForm";
 import { ProfileViewer } from "./components/ProfileViewer";
+import { NativeProfileViewer } from "./components/NativeProfileViewer";
 import { LaunchButton } from "./components/LaunchButton";
 import { StatusIndicator } from "./components/StatusIndicator";
 import { LoginPage } from "./components/LoginPage";
@@ -243,13 +244,17 @@ function AppContent({ authRequired, onLogout }: AppContentProps) {
           )}
 
           {view === "view" && selected && selected.status === "running" && (
-            <ProfileViewer
-              key={selected.id}
-              profileId={selected.id}
-              cdpUrl={selected.cdp_url}
-              clipboardSync={selected.clipboard_sync}
-              onDisconnect={handleVncDisconnect}
-            />
+            selected.vnc_ws_port === null ? (
+              <NativeProfileViewer profile={selected} />
+            ) : (
+              <ProfileViewer
+                key={selected.id}
+                profileId={selected.id}
+                cdpUrl={selected.cdp_url}
+                clipboardSync={selected.clipboard_sync}
+                onDisconnect={handleVncDisconnect}
+              />
+            )
           )}
         </div>
       </div>

--- a/frontend/src/components/NativeProfileViewer.tsx
+++ b/frontend/src/components/NativeProfileViewer.tsx
@@ -1,0 +1,21 @@
+import { ExternalLink } from "lucide-react";
+import type { Profile } from "../lib/api";
+
+export function NativeProfileViewer({ profile }: { profile: Profile }) {
+  return (
+    <div className="flex h-full items-center justify-center p-8">
+      <div className="max-w-lg rounded-xl border border-gray-800 bg-surface-1 p-8 text-center">
+        <ExternalLink className="mx-auto mb-4 h-8 w-8 text-blue-400" />
+        <h2 className="text-lg font-medium text-gray-100">Opened in macOS window</h2>
+        <p className="mt-2 text-sm text-gray-400">
+          {profile.name} runs through its native CloakBrowser profile. No VNC session needed.
+        </p>
+        {profile.notes && (
+          <pre className="mt-5 whitespace-pre-wrap rounded-lg bg-surface-0 p-4 text-left text-xs text-gray-400">
+            {profile.notes}
+          </pre>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -62,8 +62,8 @@ export interface ProfileCreateData {
 export interface LaunchResult {
   profile_id: string;
   status: string;
-  vnc_ws_port: number;
-  display: string;
+  vnc_ws_port: number | null;
+  display: string | null;
   cdp_url: string | null;
 }
 


### PR DESCRIPTION
## Summary
- launch existing native macOS CloakBrowser profiles from Manager
- sync a local non-secret profile registry into Manager UI
- support native-window status instead of noVNC
- document recommended browser-agent control through Manager CDP

## Validation
- backend: 185 passed
- frontend: 16 passed
- frontend production build passed
- live native Google profile launch and Manager CDP connection verified