### PR TITLE
fix(docker): align Windows persona fonts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,14 +3,10 @@
 #   cp .env.example .env
 # Loaded automatically at startup (Docker and native). Never commit `.env`.
 
-# Your CloakBrowser Pro license key. One key per Manager instance — every
-# launched profile shares its concurrency-seat pool. Leave blank to run the
-# free keyless build. Get a key (free GitHub key or paid) at cloakbrowser.dev.
-CLOAKBROWSER_LICENSE_KEY=
-
-# Which build to download/run: "stable" (default) or "preview".
-# Preview needs a valid key; ignored on the keyless build.
-CLOAKBROWSER_RELEASE_CHANNEL=stable
+# Optional binary cache directory. Leave blank to store binaries under the
+# Manager data directory. Docker persists /data/binaries through the /data mount.
+# For a separate volume, set this path and mount the same path in Compose.
+CLOAKBROWSER_CACHE_DIR=
 
 # Optional: require this bearer token / cookie to use the Manager. Blank = open.
 AUTH_TOKEN=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to CloakBrowser Manager are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Linux Docker font identity now matches the Windows persona more closely.** The image includes the recommended emoji and CJK baseline fonts, replaces the incomplete XP-era core-font download with a private licensed-font mount, refreshes that mount at startup, and enables CloakBrowser's Windows font-metrics profile for Linux sessions.
+
 ## [0.1.4] - 2026-08-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Per-profile license keys and browser versions.** Every profile now owns its CloakBrowser key, Stable/Preview channel, and optional exact Chromium version pin. Keyless profiles default to the public 145 build, while licensed profiles can track their channel or roll back to an exact version.
+- **Persistent multi-version browser cache.** Browser binaries download on demand when a profile starts, default to the Manager data directory, can use an external `CLOAKBROWSER_CACHE_DIR` mount, and can be inspected or cleaned from the gear panel.
+
+### Changed
+- **Removed global browser licensing.** `CLOAKBROWSER_LICENSE_KEY` and `CLOAKBROWSER_RELEASE_CHANNEL` are no longer runtime settings. Existing values migrate once to existing profiles, and new profiles start keyless. Docker images no longer download a browser during build.
+
 ### Fixed
 - **Linux Docker font identity now matches the Windows persona more closely.** The image includes the recommended emoji and CJK baseline fonts, replaces the incomplete XP-era core-font download with a private licensed-font mount, refreshes that mount at startup, and enables CloakBrowser's Windows font-metrics profile for Linux sessions.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,19 +18,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxcb1 libxext6 libxshmfence1 \
     libglib2.0-0 libgtk-3-0 libpangocairo-1.0-0 libcairo-gobject2 \
     libgdk-pixbuf-2.0-0 libxss1 libxtst6 fonts-liberation \
+    fonts-noto-color-emoji fonts-freefont-ttf fonts-unifont \
+    fonts-ipafont-gothic fonts-wqy-zenhei fonts-tlwg-loma-otf \
     libgl1-mesa-dri libegl-mesa0 \
     procps wget ca-certificates xclip \
     && rm -rf /var/lib/apt/lists/*
 
 # Playwright system deps (matches test-infra)
 RUN pip install --no-cache-dir playwright && playwright install-deps chromium 2>/dev/null || true && pip uninstall -y playwright
-
-# Windows core fonts (Arial, Times New Roman, Verdana, etc.)
-RUN echo "deb http://deb.debian.org/debian trixie contrib" >> /etc/apt/sources.list.d/contrib.list \
-    && echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | debconf-set-selections \
-    && apt-get update && apt-get install -y --no-install-recommends ttf-mscorefonts-installer \
-    && fc-cache -f \
-    && rm -rf /var/lib/apt/lists/*
 
 # Install KasmVNC (auto-selects amd64 or arm64 based on build platform)
 ARG TARGETARCH

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,6 @@ COPY backend/ /app/backend/
 # Frontend build from stage 1
 COPY --from=frontend-builder /build/dist /app/frontend/dist
 
-# Pre-download CloakBrowser binary
-RUN python -c "from cloakbrowser.download import ensure_binary; ensure_binary()"
 
 EXPOSE 8080
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,23 @@ npm run dev
 docker compose up --build
 ```
 
+Linux containers present a Windows browser persona. For coherent emoji, CJK,
+and canvas rendering, the image includes CloakBrowser's recommended baseline
+font packages. To supply separately licensed Windows fonts, keep them outside
+the repository and mount them read-only into Fontconfig's local font directory:
+
+```yaml
+services:
+  manager:
+    volumes:
+      - ~/.cloakbrowser-manager:/data
+      - /srv/cloakbrowser-manager/fonts/windows:/usr/local/share/fonts/windows:ro
+```
+
+The container refreshes the mounted directory's Fontconfig cache at startup.
+After recreating it, `/api/status` and the top-bar badge report whether all
+required Windows persona font families are available.
+
 ## Requirements
 
 - Windows or macOS native: Python 3.10+, Node.js 18+

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ Download the installer from the [latest release](https://github.com/CloakHQ/Cloa
 - **macOS** — open the `.dmg` and drag **CloakBrowser Manager** into Applications. (Unsigned during early access — on first launch, run `xattr -rc "/Applications/CloakBrowser Manager.app"` in Terminal, or approve it under **System Settings → Privacy & Security → Open Anyway**.)
 - **Windows** — run the setup `.exe`. (Unsigned during early access — if SmartScreen warns, click **More info → Run anyway**.)
 
-No Python, Node, or git required. The Manager starts on `127.0.0.1:8080` and opens in your default browser. On first launch it downloads the CloakBrowser engine. Profiles are stored in `%LOCALAPPDATA%\CloakBrowser Manager` on Windows and `~/Library/Application Support/CloakBrowser Manager` on macOS; a `logs/manager.log` in that folder records what happened if you need it.
+No Python, Node, or git required. The Manager starts on `127.0.0.1:8080` and opens in your default browser. A profile downloads its selected CloakBrowser engine only when it is first launched. Profiles and downloaded browser versions are stored in `%LOCALAPPDATA%\CloakBrowser Manager` on Windows and `~/Library/Application Support/CloakBrowser Manager` on macOS; a `logs/manager.log` in that folder records what happened if you need it.
 
-Open **Settings** (gear icon, top right) to add your license key and pick the Stable or Preview channel.
+Set the license key, Stable/Preview channel, and optional exact browser version in each profile.
 
 #### Run from source (developers)
 
@@ -71,29 +71,18 @@ Open [http://localhost:8080](http://localhost:8080), create a profile, and click
 
 > **Early alpha** — this project is under active development. Expect bugs. If you find one, please [open an issue](https://github.com/CloakHQ/CloakBrowser-Manager/issues) and attach the log so we can help. On Windows/macOS it's `logs/manager.log` in the data folder (`%LOCALAPPDATA%\CloakBrowser Manager` / `~/Library/Application Support/CloakBrowser Manager`); on Linux/Docker use `docker logs <container>`.
 
-## CloakBrowser license key
+## Profile browser versions and license keys
 
-The Manager runs on the CloakBrowser engine, so it needs a key.<br>
-[Get a free one with GitHub](https://cloakbrowser.dev/free) to run one profile at a time on the current build.<br>
-[Paid plans](https://cloakbrowser.dev) raise how many profiles run at the same time, from a handful to thousands.
+Browser selection belongs to the profile, not the Manager deployment. Each profile can use a different CloakBrowser license key, release channel, and exact Chromium version.
 
-Add your key once and every profile uses it.
+- Leave the license key empty to use the public legacy Chromium `145.0.7632.109.2` build by default. Linux ARM64 uses the wrapper's platform keyless build because no public 145 ARM64 asset exists.
+- Add a free or paid key to use the licensed build selected by the Stable or Preview channel.
+- Leave **Browser version** empty for automatic selection, or enter a full version such as `148.0.7778.215.2` to pin or roll back a paid or keyless profile. CloakBrowser free keys always resolve to the latest licensed build.
+- Click **Save and download/update now** to prepare a stopped profile immediately. Otherwise the Manager checks and downloads the binary when the profile launches.
 
-**Native app (Windows/macOS):** open **Settings** (gear icon, top right), paste your key, choose the Stable or Preview channel, and Save. It applies immediately, no restart. The badge in the top bar shows which tier and binary version are active.
+The API never returns the raw key after it is saved; profile responses expose only whether a key exists and a masked value. Existing installations migrate the former global key and channel to every existing profile once. New profiles remain keyless until configured.
 
-**Docker or run-from-source:** set it in a manager-root `.env` instead:
-
-```bash
-cp .env.example .env
-```
-
-```bash
-# .env
-CLOAKBROWSER_LICENSE_KEY=cb_your_key_here
-CLOAKBROWSER_RELEASE_CHANNEL=stable   # or: preview
-```
-
-The file is loaded automatically at startup. Restart the Manager after changing it. With Docker, you can also pass the key with `-e CLOAKBROWSER_LICENSE_KEY=...`. An environment variable overrides the in-app setting.
+The gear panel lists installed versions and can delete versions not referenced by any profile or running session.
 
 ## Why Not a Cloud Anti-Detect Browser?
 
@@ -115,6 +104,8 @@ CloakBrowser Manager runs on your own machine, and every profile inherits the Cl
 
 - **Unlimited profiles, no per-profile tax** — create as many identities as you want. You pay only for how many run at the same time, not how many you keep. Dormant accounts cost nothing.
 - **Each profile is a different machine** — its own fingerprint seed, GPU family, screen, cookies, localStorage, cache, and history, persistent across restarts
+- **Per-profile browser selection** — assign a different license key, Stable/Preview channel, and exact CloakBrowser version to every profile, or run keyless on the legacy 145 build
+- **Persistent multi-version cache** — binaries download on first use, survive container recreation, and unused versions can be cleaned from the gear panel
 - **Per-profile network and locale** — proxy, GeoIP, timezone, locale, and screen, per profile; timezone and language follow the proxy exit IP automatically
 - **Platform-aware hardware profiles** — automatic Apple Silicon selection and configurable Windows GPU families, coherent within each profile
 - **Profile organization** — create, search, tag, edit, auto-launch, and delete profiles
@@ -124,7 +115,7 @@ CloakBrowser Manager runs on your own machine, and every profile inherits the Cl
 - **Humanized interaction** — optional human-like mouse, keyboard, and scrolling behavior
 - **Compatibility controls** — unpacked extensions, third-party-cookie support, and advanced Chromium arguments
 - **Clipboard sync** — copy and paste between the Manager and Linux VNC browser profiles
-- **License and system status** — see the active tier, binary version, and Windows font health in the top bar
+- **System status** — see the number and location of cached browser versions and Windows font health in the top bar
 - **Optional authentication** — protect the web UI and API with a single token, or run locally without authentication
 - **Powered by CloakBrowser** — the identities don't just look different, they hold up: a source-level C++ patched Chromium engine tested against Cloudflare Turnstile, reCAPTCHA v3, FingerprintJS, and BrowserScan
 
@@ -173,6 +164,21 @@ services:
       - /srv/cloakbrowser-manager/fonts/windows:/usr/local/share/fonts/windows:ro
 ```
 
+Downloaded browsers default to the Manager data directory (`/data/binaries` in Docker), so the existing `/data` mount preserves them across container recreation. To use a separate host path or named volume, set `CLOAKBROWSER_CACHE_DIR` to the mounted container path:
+
+```yaml
+services:
+  manager:
+    environment:
+      CLOAKBROWSER_CACHE_DIR: /browser-cache
+    volumes:
+      - ~/.cloakbrowser-manager:/data
+      - cloakbrowser-binaries:/browser-cache
+
+volumes:
+  cloakbrowser-binaries:
+```
+
 The container refreshes the mounted directory's Fontconfig cache at startup.
 After recreating it, `/api/status` and the top-bar badge report whether all
 required Windows persona font families are available.
@@ -210,7 +216,7 @@ docker rm <container-id>
 docker run -p 127.0.0.1:8080:8080 -v cloakprofiles:/data cloakhq/cloakbrowser-manager
 ```
 
-Profiles and session data remain in the native application-data directory or the `cloakprofiles` Docker volume across updates.
+Profiles, session data, and downloaded browser versions remain in the native application-data directory or the `/data` Docker volume across updates.
 
 ## Automation API
 

--- a/backend/binary_cache.py
+++ b/backend/binary_cache.py
@@ -1,0 +1,239 @@
+"""Per-profile CloakBrowser binary resolution and cache management."""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+LEGACY_KEYLESS_VERSION = "145.0.7632.109.2"
+LEGACY_KEYLESS_PLATFORMS = frozenset(
+    {"linux-x64", "darwin-arm64", "darwin-x64", "windows-x64"}
+)
+_VERSION_RE = re.compile(r"^[0-9]+(?:\.[0-9]+){3,4}$")
+_CACHE_DIR_RE = re.compile(
+    r"^chromium-(?P<version>[0-9]+(?:\.[0-9]+){3,4})(?P<pro>-pro)?$"
+)
+
+
+@dataclass(frozen=True)
+class BinaryRequest:
+    license_key: str | None
+    browser_version: str | None
+    release_channel: str
+
+    @property
+    def tier(self) -> str:
+        return "licensed" if self.license_key else "keyless"
+
+
+@dataclass(frozen=True)
+class PreparedBinary:
+    version: str | None
+    tier: str
+    binary_path: str
+    cache_dir: str | None
+
+
+def _clean_optional(value: Any) -> str | None:
+    if value is None:
+        return None
+    cleaned = str(value).strip()
+    return cleaned or None
+
+
+def normalize_version(value: Any) -> str | None:
+    version = _clean_optional(value)
+    if version is None:
+        return None
+    if not _VERSION_RE.fullmatch(version):
+        raise ValueError(
+            "Invalid browser version. Use a full numeric Chromium version, "
+            "for example '145.0.7632.109.2'."
+        )
+    return version
+
+
+def profile_binary_request(profile: dict[str, Any]) -> BinaryRequest:
+    """Resolve one profile's license, channel, and optional exact version pin."""
+    license_key = _clean_optional(profile.get("license_key"))
+    release_channel = str(profile.get("release_channel") or "stable").strip().lower()
+    if release_channel not in {"stable", "preview"}:
+        raise ValueError("release_channel must be 'stable' or 'preview'")
+
+    browser_version = normalize_version(profile.get("browser_version"))
+    if license_key is None and browser_version is None:
+        from cloakbrowser.config import get_platform_tag
+
+        if get_platform_tag() in LEGACY_KEYLESS_PLATFORMS:
+            browser_version = LEGACY_KEYLESS_VERSION
+
+    return BinaryRequest(
+        license_key=license_key,
+        browser_version=browser_version,
+        release_channel=release_channel,
+    )
+
+
+def _cache_identity(binary_path: Path) -> tuple[str | None, str, Path | None]:
+    for parent in (binary_path, *binary_path.parents):
+        match = _CACHE_DIR_RE.fullmatch(parent.name)
+        if match:
+            tier = "licensed" if match.group("pro") else "keyless"
+            return match.group("version"), tier, parent
+    return None, "external", None
+
+
+def ensure_profile_binary(profile: dict[str, Any]) -> PreparedBinary:
+    """Ensure the profile's selected binary exists, downloading it when absent."""
+    from cloakbrowser.download import ensure_binary
+
+    request = profile_binary_request(profile)
+    path = Path(
+        ensure_binary(
+            license_key=request.license_key,
+            browser_version=request.browser_version,
+            release_channel=request.release_channel,
+        )
+    )
+    version, tier, cache_dir = _cache_identity(path)
+    return PreparedBinary(
+        version=version or request.browser_version,
+        tier=tier if tier != "external" else request.tier,
+        binary_path=str(path),
+        cache_dir=str(cache_dir) if cache_dir else None,
+    )
+
+
+def cache_dir() -> Path:
+    from cloakbrowser.config import get_cache_dir
+
+    return get_cache_dir()
+
+
+def assert_no_global_license_file() -> None:
+    """Reject wrapper-global cached keys that would leak into keyless profiles."""
+    key_file = cache_dir() / "license.key"
+    if key_file.exists():
+        raise RuntimeError(
+            f"Global CloakBrowser key file is not supported: {key_file}. "
+            "Move the key into each profile, then remove this file."
+        )
+
+
+def _directory_size(path: Path) -> int:
+    total = 0
+    for root, _directories, files in os.walk(path):
+        for filename in files:
+            try:
+                total += (Path(root) / filename).stat().st_size
+            except OSError:
+                continue
+    return total
+
+
+def _configured_references(profile: dict[str, Any]) -> set[tuple[str, str]]:
+    request = profile_binary_request(profile)
+    if not request.license_key:
+        return (
+            {(request.browser_version, "keyless")}
+            if request.browser_version
+            else set()
+        )
+
+    from cloakbrowser.config import get_effective_version
+
+    references: set[tuple[str, str]] = set()
+    if request.browser_version:
+        # A valid key uses the licensed cache. An invalid/unreachable key can
+        # fall back to the public cache, so preserve either result.
+        references.add((request.browser_version, "licensed"))
+        references.add((request.browser_version, "keyless"))
+    pro_version = get_effective_version(
+        pro=True,
+        release_channel=request.release_channel,
+    )
+    if pro_version:
+        references.add((pro_version, "licensed"))
+    return references
+
+
+def _references(
+    profiles: Iterable[dict[str, Any]],
+    running_profiles: Iterable[Any],
+) -> dict[tuple[str, str], dict[str, int]]:
+    references: dict[tuple[str, str], dict[str, int]] = {}
+    for profile in profiles:
+        for reference in _configured_references(profile):
+            counts = references.setdefault(reference, {"profiles": 0, "running": 0})
+            counts["profiles"] += 1
+
+    for running in running_profiles:
+        version = getattr(running, "browser_version", None)
+        tier = getattr(running, "binary_tier", None)
+        if not version or tier not in {"licensed", "keyless"}:
+            continue
+        counts = references.setdefault((version, tier), {"profiles": 0, "running": 0})
+        counts["running"] += 1
+    return references
+
+
+def list_installed_binaries(
+    profiles: Iterable[dict[str, Any]],
+    running_profiles: Iterable[Any],
+) -> list[dict[str, Any]]:
+    root = cache_dir()
+    references = _references(profiles, running_profiles)
+    binaries: list[dict[str, Any]] = []
+    if not root.exists():
+        return binaries
+
+    for child in root.iterdir():
+        if child.is_symlink() or not child.is_dir():
+            continue
+        match = _CACHE_DIR_RE.fullmatch(child.name)
+        if not match:
+            continue
+        version = match.group("version")
+        tier = "licensed" if match.group("pro") else "keyless"
+        counts = references.get((version, tier), {"profiles": 0, "running": 0})
+        binaries.append(
+            {
+                "version": version,
+                "tier": tier,
+                "path": str(child),
+                "size_bytes": _directory_size(child),
+                "profile_count": counts["profiles"],
+                "running_count": counts["running"],
+                "in_use": bool(counts["profiles"] or counts["running"]),
+            }
+        )
+
+    binaries.sort(
+        key=lambda item: tuple(int(part) for part in item["version"].split(".")),
+        reverse=True,
+    )
+    return binaries
+
+
+
+
+def cleanup_unused_binaries(
+    profiles: Iterable[dict[str, Any]],
+    running_profiles: Iterable[Any],
+) -> tuple[list[dict[str, Any]], int]:
+    installed = list_installed_binaries(profiles, running_profiles)
+    removed: list[dict[str, Any]] = []
+    reclaimed = 0
+    for binary in installed:
+        if binary["in_use"]:
+            continue
+        path = Path(binary["path"])
+        shutil.rmtree(path)
+        removed.append(binary)
+        reclaimed += int(binary["size_bytes"])
+
+    return removed, reclaimed

--- a/backend/browser_manager.py
+++ b/backend/browser_manager.py
@@ -1031,6 +1031,10 @@ class BrowserManager:
         # Persona is always determined by the runtime, not editable profile data.
         platform = "macos" if self.runtime.host_os == "macos" else "windows"
         args.append(f"--fingerprint-platform={platform}")
+        # The Linux runtime presents a Windows persona. With licensed Windows
+        # fonts mounted, align Chromium's text measurements with that persona.
+        if self.runtime.host_os == "linux":
+            args.append("--fingerprint-windows-font-metrics")
 
         # Apple GPU models are selected automatically by the seeded macOS
         # persona. Windows vendor-family overrides are incoherent on macOS.

--- a/backend/browser_manager.py
+++ b/backend/browser_manager.py
@@ -21,6 +21,7 @@ from cloakbrowser.license import (
 )
 
 from .runtime import RuntimeConfig, resolve_runtime
+from .binary_cache import PreparedBinary, ensure_profile_binary, profile_binary_request
 from .vnc_manager import VNCManager
 
 logger = logging.getLogger("cloakbrowser.manager.browser")
@@ -315,24 +316,16 @@ class RunningProfile:
     # context_async on the returned context). Read on close to tell a seat/
     # license denial apart from a real crash or a user-initiated close.
     denial_path: str | None = None
+    browser_version: str | None = None
+    binary_tier: str = "keyless"
 
 
 class BrowserManager:
     def __init__(
         self,
         runtime_config: RuntimeConfig | None = None,
-        license_key: str | None = None,
-        release_channel: str | None = None,
     ):
         self.runtime = runtime_config or resolve_runtime()
-        # App-wide license: passed to every launch so the wrapper downloads the
-        # Pro build and injects the key the Pro binary needs to boot + take a seat.
-        self.license_key = license_key
-        self.release_channel = release_channel
-        # Resolved at startup by resolve_binary_status(); read by GET /api/status.
-        self.license_tier = "keyless"
-        self.license_plan: str | None = None
-        self.binary_version: str | None = None
         self.running: dict[str, RunningProfile] = {}
         # Last launch failure per profile, surfaced on the status poll and cleared
         # on the next launch. Holds post-handshake denials (out of seats, bad key)
@@ -346,60 +339,12 @@ class BrowserManager:
         self._lock = asyncio.Lock()
         self._cdp_ports: set[int] = set()
         self._auto_launch_task: asyncio.Task | None = None
+        self._binary_lock = asyncio.Lock()
 
-    def resolve_binary_status(self) -> None:
-        """Resolve the license tier + binary version and pre-download the binary.
-
-        Blocking — called once at startup (via a thread) so the multi-hundred-MB
-        Pro download stays out of the launch path and auto-launch's 60s timeout.
-        Never raises: on any failure the keyless baked-in binary remains usable.
-        """
-        from cloakbrowser.config import CHROMIUM_VERSION, get_chromium_version
-        from cloakbrowser.download import ensure_binary
-        from cloakbrowser.license import (
-            get_pro_latest_version,
-            resolve_license_key,
-            validate_license,
-        )
-
-        try:
-            keyless_version = get_chromium_version()
-        except Exception:
-            keyless_version = CHROMIUM_VERSION
-
-        tier = "keyless"
-        version = keyless_version
-
-        key = resolve_license_key(self.license_key)
-        if key:
-            try:
-                info = validate_license(key)
-            except Exception as exc:
-                info = None
-                logger.warning("License validation failed: %s", exc)
-            if info and info.valid:
-                tier = "free" if info.plan == "free" else "pro"
-                self.license_plan = info.plan
-                try:
-                    version = get_pro_latest_version(self.release_channel) or keyless_version
-                except Exception as exc:
-                    logger.warning("Could not resolve Pro version: %s", exc)
-
-        self.license_tier = tier
-        self.binary_version = version
-
-        try:
-            ensure_binary(
-                license_key=self.license_key,
-                release_channel=self.release_channel,
-            )
-            logger.info("Binary ready: tier=%s version=%s", tier, version)
-        except Exception as exc:
-            logger.error(
-                "Binary pre-download failed (keyless fallback remains): %s",
-                exc,
-                exc_info=True,
-            )
+    async def prepare_binary(self, profile: dict[str, Any]) -> PreparedBinary:
+        """Resolve and download one profile's browser binary on demand."""
+        async with self._binary_lock:
+            return await asyncio.to_thread(ensure_profile_binary, profile)
 
     async def launch(self, profile: dict[str, Any]) -> RunningProfile:
         """Launch a browser instance using the configured host runtime."""
@@ -409,13 +354,14 @@ class BrowserManager:
         # produced it. Proxy credentials are redacted; never log the key.
         from . import diagnostics
 
+        request = profile_binary_request(profile)
         logger.info(
-            "Launching profile %s: seed=%s proxy=%s tier=%s plan=%s runtime=%s",
+            "Launching profile %s: seed=%s proxy=%s browser=%s channel=%s runtime=%s",
             profile_id,
             profile.get("fingerprint_seed"),
             diagnostics.redact_proxy(profile.get("proxy")),
-            self.license_tier,
-            self.license_plan or "-",
+            request.browser_version or ("latest" if request.license_key else "platform-default"),
+            request.release_channel,
             self.runtime.runtime_mode,
         )
 
@@ -431,7 +377,9 @@ class BrowserManager:
         ws_port: int | None = None
         cdp_port: int | None = None
         context: Any | None = None
+        prepared: PreparedBinary | None = None
         try:
+            prepared = await self.prepare_binary(profile)
             if self.runtime.viewer_mode == "vnc":
                 display, ws_port = await self.vnc.allocate()
 
@@ -450,7 +398,7 @@ class BrowserManager:
             # reports "initializing" via get_status while it works (one short
             # headless launch). Never fatal.
             if profile.get("set_google_default", True):
-                await self._ensure_search_engine(profile_id, user_data_dir)
+                await self._ensure_search_engine(profile, user_data_dir)
 
             if display is not None and ws_port is not None:
                 await self.vnc.start_vnc(
@@ -496,8 +444,9 @@ class BrowserManager:
                 "geoip": bool(profile.get("geoip", False)),
                 "color_scheme": profile.get("color_scheme") or None,
                 "extension_paths": profile.get("extension_paths") or [],
-                "license_key": self.license_key,
-                "release_channel": self.release_channel,
+                "license_key": request.license_key,
+                "browser_version": request.browser_version,
+                "release_channel": request.release_channel,
             }
             if display is not None:
                 launch_options["viewport"] = {
@@ -599,6 +548,8 @@ class BrowserManager:
                 user_data_dir=user_data_dir,
                 capture_preview=bool(profile.get("capture_preview", True)),
                 denial_path=getattr(context, "_cloak_denial_path", None),
+                browser_version=prepared.version if prepared else request.browser_version,
+                binary_tier=prepared.tier if prepared else request.tier,
             )
             context.on(
                 "close",
@@ -640,7 +591,7 @@ class BrowserManager:
             raise
 
     async def _ensure_search_engine(
-        self, profile_id: str, user_data_dir: Path
+        self, profile: dict[str, Any], user_data_dir: Path
     ) -> None:
         """Make Google the default search engine, once per profile.
 
@@ -653,6 +604,7 @@ class BrowserManager:
         so a persistently-failing profile doesn't pay an extra headless launch
         (~5s) on every single launch, silently, forever.
         """
+        profile_id = profile["id"]
         marker = user_data_dir / SEARCH_ENGINE_MARKER
         state = marker.read_text().strip() if marker.exists() else ""
         if state == "google":
@@ -668,7 +620,7 @@ class BrowserManager:
 
         self._initializing.add(profile_id)
         try:
-            await self._setup_google_default(user_data_dir)
+            await self._setup_google_default(profile, user_data_dir)
             marker.parent.mkdir(parents=True, exist_ok=True)
             marker.write_text("google\n")
             logger.info(
@@ -697,7 +649,9 @@ class BrowserManager:
         finally:
             self._initializing.discard(profile_id)
 
-    async def _setup_google_default(self, user_data_dir: Path) -> None:
+    async def _setup_google_default(
+        self, profile: dict[str, Any], user_data_dir: Path
+    ) -> None:
         """Add Google via the settings UI, then commit it as the default.
 
         Single headless launch, no file seeding. A plain Preferences write can't
@@ -708,7 +662,7 @@ class BrowserManager:
         dialog — Chrome creates the row with a valid hash — then "Make default".
         Every later launch then carries Google via the profile's own files.
         """
-        ctx = await self._headless_launch(user_data_dir)
+        ctx = await self._headless_launch(profile, user_data_dir)
         try:
             page = await ctx.new_page()
             await page.goto("chrome://settings/searchEngines")
@@ -749,15 +703,19 @@ class BrowserManager:
             await self._close_context(ctx, "search-init")
         await asyncio.sleep(0.5)
 
-    async def _headless_launch(self, user_data_dir: Path) -> Any:
+    async def _headless_launch(
+        self, profile: dict[str, Any], user_data_dir: Path
+    ) -> Any:
         """Short headless launch used only by the one-time search-engine setup."""
         for lock_file in ("SingletonLock", "SingletonCookie", "SingletonSocket"):
             (user_data_dir / lock_file).unlink(missing_ok=True)
+        request = profile_binary_request(profile)
         return await launch_persistent_context_async(
             user_data_dir=str(user_data_dir),
             headless=True,
-            license_key=self.license_key,
-            release_channel=self.release_channel,
+            license_key=request.license_key,
+            browser_version=request.browser_version,
+            release_channel=request.release_channel,
         )
 
     async def _capture_screenshot(self, running: RunningProfile) -> None:
@@ -944,7 +902,7 @@ class BrowserManager:
         logger.info("Auto-launching %d profile(s)...", len(auto_profiles))
         for profile in auto_profiles:
             try:
-                await asyncio.wait_for(self.launch(profile), timeout=60)
+                await self.launch(profile)
                 logger.info("Auto-launched profile %s (%s)", profile["name"], profile["id"])
             except Exception as exc:
                 logger.error(

--- a/backend/database.py
+++ b/backend/database.py
@@ -18,9 +18,10 @@ DATA_DIR = RUNTIME.data_dir
 DB_PATH = DATA_DIR / "profiles.db"
 
 _PROFILE_COLUMNS = (
-    "id", "name", "fingerprint_seed", "proxy", "timezone", "locale",
-    "screen_width", "screen_height", "gpu_family", "humanize", "human_preset",
-    "geoip", "clipboard_sync", "auto_launch", "color_scheme", "launch_args",
+    "id", "name", "license_key", "release_channel", "browser_version",
+    "fingerprint_seed", "proxy", "timezone", "locale", "screen_width",
+    "screen_height", "gpu_family", "humanize", "human_preset", "geoip",
+    "clipboard_sync", "auto_launch", "color_scheme", "launch_args",
     "extension_paths", "allow_3p_cookies", "set_google_default", "capture_preview",
     "restore_session", "notes", "user_data_dir", "created_at", "updated_at", "sort_order",
 )
@@ -29,6 +30,9 @@ _PROFILE_SCHEMA = """
 CREATE TABLE profiles (
     id TEXT PRIMARY KEY,
     name TEXT NOT NULL,
+    license_key TEXT,
+    release_channel TEXT NOT NULL DEFAULT 'stable',
+    browser_version TEXT,
     fingerprint_seed INTEGER NOT NULL,
     proxy TEXT,
     timezone TEXT,
@@ -78,6 +82,15 @@ def _create_tags_table(conn: sqlite3.Connection) -> None:
             PRIMARY KEY (profile_id, tag)
         )
     """)
+def _create_metadata_table(conn: sqlite3.Connection) -> None:
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS manager_metadata (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        )
+    """)
+
+
 
 
 def _rebuild_profiles(conn: sqlite3.Connection, old_columns: set[str]) -> None:
@@ -145,18 +158,56 @@ def _rebuild_profiles(conn: sqlite3.Connection, old_columns: set[str]) -> None:
 def init_db():
     DB_PATH.parent.mkdir(parents=True, exist_ok=True)
     with get_db() as conn:
-        exists = conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='profiles'").fetchone()
+        exists = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='profiles'"
+        ).fetchone()
         if not exists:
             conn.execute(_PROFILE_SCHEMA)
             _create_tags_table(conn)
+            _create_metadata_table(conn)
             conn.commit()
             return
-        old_columns = {row[1] for row in conn.execute("PRAGMA table_info(profiles)").fetchall()}
+        old_columns = {
+            row[1] for row in conn.execute("PRAGMA table_info(profiles)").fetchall()
+        }
         if old_columns != set(_PROFILE_COLUMNS):
             _rebuild_profiles(conn, old_columns)
         else:
             _create_tags_table(conn)
-            conn.commit()
+        _create_metadata_table(conn)
+        conn.commit()
+
+
+def migrate_legacy_browser_settings(
+    license_key: str | None,
+    release_channel: str | None,
+) -> int:
+    """Copy the former global browser settings to existing profiles once."""
+    migration_key = "profile_browser_settings_v1"
+    with get_db() as conn:
+        migrated = conn.execute(
+            "SELECT 1 FROM manager_metadata WHERE key = ?", (migration_key,)
+        ).fetchone()
+        if migrated:
+            return 0
+
+        key = (license_key or "").strip() or None
+        channel = (release_channel or "stable").strip().lower()
+        if channel not in {"stable", "preview"}:
+            channel = "stable"
+        cursor = conn.execute(
+            """
+            UPDATE profiles
+            SET license_key = ?, release_channel = ?, updated_at = ?
+            """,
+            (key, channel, _now()),
+        )
+        conn.execute(
+            "INSERT INTO manager_metadata (key, value) VALUES (?, ?)",
+            (migration_key, _now()),
+        )
+        conn.commit()
+        return cursor.rowcount
 
 
 def _now() -> str:
@@ -179,6 +230,9 @@ def create_profile(name: str, fingerprint_seed: int | None = None, **fields: Any
     tags = fields.pop("tags", None) or []
     values = {
         "id": profile_id, "name": name, "fingerprint_seed": seed,
+        "license_key": fields.get("license_key"),
+        "release_channel": fields.get("release_channel", "stable"),
+        "browser_version": fields.get("browser_version"),
         "proxy": fields.get("proxy"), "timezone": fields.get("timezone"), "locale": fields.get("locale"),
         "screen_width": fields.get("screen_width", 1920), "screen_height": fields.get("screen_height", 1080),
         "gpu_family": fields.get("gpu_family", "auto"), "humanize": fields.get("humanize", False),

--- a/backend/diagnostics.py
+++ b/backend/diagnostics.py
@@ -127,10 +127,8 @@ def startup_line(browser_mgr) -> str:
         f"ui={os.environ.get('CLOAKBROWSER_MANAGER_UI', 'auto')} "
         f"runtime={getattr(rt, 'runtime_mode', '?')} "
         f"host_os={getattr(rt, 'host_os', '?')} data_dir={data_dir} | "
-        f"tier={getattr(browser_mgr, 'license_tier', '?')} "
-        f"plan={getattr(browser_mgr, 'license_plan', None) or '-'} "
         f"wrapper={wrapper_version()} "
-        f"binary={getattr(browser_mgr, 'binary_version', None) or '?'}"
+        f"binary_cache={os.environ.get('CLOAKBROWSER_CACHE_DIR', '?')}"
     )
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -30,11 +30,21 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 from .env_file import load_env_file
 
-# Populate os.environ from the manager-root .env before anything reads it
-# (database.resolve_runtime, AUTH_TOKEN, the license config below).
+# Load the legacy deployment settings once, then remove them before importing
+# cloakbrowser. Explicit per-profile arguments must be the only license source.
 load_env_file()
+_LEGACY_ENV_LICENSE_KEY = os.environ.pop("CLOAKBROWSER_LICENSE_KEY", None)
+_LEGACY_ENV_RELEASE_CHANNEL = os.environ.pop("CLOAKBROWSER_RELEASE_CHANNEL", None)
+os.environ.pop("CLOAKBROWSER_VERSION", None)
+os.environ.pop("CLOAKBROWSER_BINARY_PATH", None)
 
 from . import database as db
+
+# Persist downloaded binaries with Manager data unless an external cache mount
+# was explicitly configured.
+if not os.environ.get("CLOAKBROWSER_CACHE_DIR"):
+    os.environ["CLOAKBROWSER_CACHE_DIR"] = str(db.DATA_DIR / "binaries")
+
 from cloakbrowser.license import CloakBrowserLicenseError
 
 from .browser_manager import (
@@ -45,6 +55,9 @@ from .browser_manager import (
     test_proxy,
 )
 from .models import (
+    BrowserBinaryListResponse,
+    BrowserCleanupResponse,
+    BrowserDownloadResponse,
     ClipboardRequest,
     LaunchResponse,
     LoginRequest,
@@ -55,13 +68,17 @@ from .models import (
     ProxyTestRequest,
     ProxyTestResponse,
     ReorderRequest,
-    SettingsResponse,
-    SettingsUpdate,
     StatusResponse,
     TagResponse,
     UpdateCheckResponse,
 )
 from .runtime import bundle_dir
+from .binary_cache import (
+    assert_no_global_license_file,
+    cache_dir as browser_cache_dir,
+    cleanup_unused_binaries,
+    list_installed_binaries,
+)
 from .settings_store import load_settings, save_settings
 
 logger = logging.getLogger("cloakbrowser.manager")
@@ -108,23 +125,14 @@ diagnostics.install_stderr_tee()
 # token or cookie.
 AUTH_TOKEN: str | None = os.environ.get("AUTH_TOKEN") or None
 
-# App-wide CloakBrowser Pro license. One key per Manager instance — the
-# concurrency-seat pool is per-license, so every launched profile shares it.
-# Release channel picks Stable vs Preview builds.
-#
-# Precedence: environment (incl. values load_env_file pulled from a .env) wins,
-# then the in-app Settings (settings.json). Native users have no .env and set
-# the key in the Settings UI; Docker/CI keep overriding via env vars.
 _STORED_SETTINGS = load_settings()
-
-
-def _resolve_setting(env_key: str, settings_key: str) -> str | None:
-    return os.environ.get(env_key) or _STORED_SETTINGS.get(settings_key) or None
-
-
-LICENSE_KEY: str | None = _resolve_setting("CLOAKBROWSER_LICENSE_KEY", "license_key")
-RELEASE_CHANNEL: str | None = _resolve_setting(
-    "CLOAKBROWSER_RELEASE_CHANNEL", "release_channel"
+_LEGACY_LICENSE_KEY = (
+    _LEGACY_ENV_LICENSE_KEY or _STORED_SETTINGS.get("license_key") or None
+)
+_LEGACY_RELEASE_CHANNEL = (
+    _LEGACY_ENV_RELEASE_CHANNEL
+    or _STORED_SETTINGS.get("release_channel")
+    or "stable"
 )
 
 # Paths that bypass authentication even when AUTH_TOKEN is set
@@ -283,7 +291,7 @@ class AuthMiddleware:
 
 
 # Singleton browser manager
-browser_mgr = BrowserManager(license_key=LICENSE_KEY, release_channel=RELEASE_CHANNEL)
+browser_mgr = BrowserManager()
 
 # Frontend build directory (React production build). bundle_dir() resolves to
 # the PyInstaller extraction root when frozen, else the manager repo root.
@@ -486,10 +494,17 @@ def _filter_rfb_client_messages(data: bytes) -> bytes:
 async def lifespan(app: FastAPI):
     browser_mgr.vnc.validate_available()
     db.init_db()
+    migrated = db.migrate_legacy_browser_settings(
+        _LEGACY_LICENSE_KEY,
+        _LEGACY_RELEASE_CHANNEL,
+    )
+    migrated_settings = dict(_STORED_SETTINGS)
+    migrated_settings.pop("license_key", None)
+    migrated_settings.pop("release_channel", None)
+    if migrated_settings != _STORED_SETTINGS:
+        save_settings(migrated_settings)
+    assert_no_global_license_file()
     await browser_mgr.cleanup_stale()
-    # Resolve tier + pre-download the (Pro) binary before serving launches, so the
-    # download never blocks a launch or auto-launch's 60s timeout.
-    await asyncio.to_thread(browser_mgr.resolve_binary_status)
     diagnostics.install_asyncio_handler(asyncio.get_running_loop(), logger)
     logger.info(diagnostics.startup_line(browser_mgr))
     browser_mgr._auto_launch_task = asyncio.create_task(browser_mgr.auto_launch_all())
@@ -552,7 +567,11 @@ async def auth_logout(request: Request, response: Response):
 
 
 def _profile_response(profile: dict) -> ProfileResponse:
+    license_key = profile.get("license_key")
     payload = {**profile, **browser_mgr.get_status(profile["id"])}
+    payload.pop("license_key", None)
+    payload["license_key_set"] = bool(license_key)
+    payload["license_key_masked"] = _mask_key(license_key)
     payload["tags"] = [TagResponse(**tag) for tag in profile.get("tags", [])]
     return ProfileResponse(**payload)
 
@@ -797,27 +816,19 @@ def _windows_font_health() -> tuple[int | None, int | None, bool | None]:
 
 @app.get("/api/status", response_model=StatusResponse)
 async def get_system_status():
-    # Prefer the version/tier resolved at startup (reflects the actual Pro build
-    # in use). Fall back to the keyless constant before startup resolution runs.
-    binary_version = browser_mgr.binary_version
-    if not binary_version:
-        try:
-            from cloakbrowser.config import get_chromium_version
-
-            binary_version = get_chromium_version()
-        except ImportError:
-            from cloakbrowser.config import CHROMIUM_VERSION
-
-            binary_version = CHROMIUM_VERSION
-
     profiles = db.list_profiles()
+    installed = await asyncio.to_thread(
+        list_installed_binaries,
+        profiles,
+        list(browser_mgr.running.values()),
+    )
     fonts_present, fonts_required, fonts_complete = await asyncio.to_thread(
         _windows_font_health
     )
     return StatusResponse(
         running_count=len(browser_mgr.running),
-        binary_version=binary_version,
-        license_tier=browser_mgr.license_tier,
+        installed_binary_count=len(installed),
+        binary_cache_dir=str(browser_cache_dir()),
         profiles_total=len(profiles),
         host_os=browser_mgr.runtime.host_os,
         runtime_mode=browser_mgr.runtime.runtime_mode,
@@ -927,12 +938,6 @@ def _mask_key(key: str | None) -> str | None:
     return f"{key[:5]}…{key[-4:]}"
 
 
-def _settings_response() -> SettingsResponse:
-    return SettingsResponse(
-        license_key_set=bool(browser_mgr.license_key),
-        license_key_masked=_mask_key(browser_mgr.license_key),
-        release_channel=(browser_mgr.release_channel or "stable"),
-    )
 
 
 @app.post("/api/shutdown")
@@ -966,43 +971,65 @@ async def shutdown_manager(request: Request):
     return {"ok": True, "message": "CloakBrowser Manager is shutting down"}
 
 
-@app.get("/api/settings", response_model=SettingsResponse)
-async def get_settings():
-    return _settings_response()
+@app.get("/api/browsers", response_model=BrowserBinaryListResponse)
+async def list_browsers():
+    profiles = db.list_profiles()
+    async with browser_mgr._binary_lock:
+        binaries = await asyncio.to_thread(
+            list_installed_binaries,
+            profiles,
+            list(browser_mgr.running.values()),
+        )
+    return BrowserBinaryListResponse(
+        cache_dir=str(browser_cache_dir()),
+        binaries=binaries,
+    )
 
 
-@app.put("/api/settings", response_model=StatusResponse)
-async def update_settings(payload: SettingsUpdate):
-    """Persist license key / release channel and hot-apply without a restart.
+@app.delete("/api/browsers/unused", response_model=BrowserCleanupResponse)
+async def cleanup_browsers():
+    profiles = db.list_profiles()
+    async with browser_mgr._binary_lock:
+        removed, reclaimed = await asyncio.to_thread(
+            cleanup_unused_binaries,
+            profiles,
+            list(browser_mgr.running.values()),
+        )
+    return BrowserCleanupResponse(removed=removed, reclaimed_bytes=reclaimed)
 
-    Returns the refreshed system status (tier + resolved binary version) so the
-    top-bar badge updates immediately. Re-resolving may download the Pro build,
-    so it runs off the event loop; the request completes when it's ready.
-    """
-    stored = load_settings()
 
-    if payload.license_key is not None:
-        key = payload.license_key.strip()
-        if key:
-            stored["license_key"] = key
-            browser_mgr.license_key = key
-        else:  # empty string = clear the key (back to keyless)
-            stored.pop("license_key", None)
-            browser_mgr.license_key = None
+@app.post(
+    "/api/profiles/{profile_id}/browser/download",
+    response_model=BrowserDownloadResponse,
+)
+async def download_profile_browser(profile_id: str):
+    profile = db.get_profile(profile_id)
+    if not profile:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    if profile_id in browser_mgr.running:
+        raise HTTPException(
+            status_code=409,
+            detail="Stop the profile before updating its browser binary",
+        )
+    try:
+        prepared = await browser_mgr.prepare_binary(profile)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception as exc:
+        logger.error(
+            "Failed to prepare browser for profile %s: %s",
+            profile_id,
+            exc,
+            exc_info=True,
+        )
+        raise HTTPException(status_code=502, detail="Failed to download browser binary")
+    return BrowserDownloadResponse(
+        version=prepared.version,
+        tier=prepared.tier,
+        binary_path=prepared.binary_path,
+    )
 
-    if payload.release_channel is not None:
-        channel = payload.release_channel.strip().lower()
-        if channel not in {"stable", "preview"}:
-            raise HTTPException(
-                status_code=400,
-                detail="release_channel must be 'stable' or 'preview'",
-            )
-        stored["release_channel"] = channel
-        browser_mgr.release_channel = channel
 
-    save_settings(stored)
-    await asyncio.to_thread(browser_mgr.resolve_binary_status)
-    return await get_system_status()
 
 
 # ── Clipboard Relay ──────────────────────────────────────────────────────────

--- a/backend/models.py
+++ b/backend/models.py
@@ -7,12 +7,16 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from .runtime import HostOS, RuntimeMode, ViewerMode
+from .binary_cache import normalize_version
 
 
 class ProfileCreate(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     name: str
+    license_key: str | None = None
+    release_channel: Literal["stable", "preview"] = "stable"
+    browser_version: str | None = None
     fingerprint_seed: int | None = None
     proxy: str | None = None
     timezone: str | None = None
@@ -34,12 +38,28 @@ class ProfileCreate(BaseModel):
     restore_session: bool = True
     notes: str | None = None
     tags: list[TagCreate] | None = None
+    @field_validator("license_key", mode="before")
+    @classmethod
+    def normalize_optional_license_key(cls, value: object) -> object:
+        if not isinstance(value, str):
+            return value
+        cleaned = value.strip()
+        return cleaned or None
+
+    @field_validator("browser_version", mode="before")
+    @classmethod
+    def validate_browser_version(cls, value: object) -> object:
+        return normalize_version(value)
+
 
 
 class ProfileUpdate(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     name: str | None = None
+    license_key: str | None = Field(default=None)
+    release_channel: Literal["stable", "preview"] | None = None
+    browser_version: str | None = Field(default=None)
     fingerprint_seed: int | None = None
     proxy: str | None = Field(default=None)
     timezone: str | None = Field(default=None)
@@ -61,6 +81,26 @@ class ProfileUpdate(BaseModel):
     restore_session: bool | None = None
     notes: str | None = Field(default=None)
     tags: list[TagCreate] | None = None
+    @field_validator("license_key", mode="before")
+    @classmethod
+    def normalize_optional_license_update(cls, value: object) -> object:
+        if not isinstance(value, str):
+            return value
+        cleaned = value.strip()
+        return cleaned or None
+
+    @field_validator("browser_version", mode="before")
+    @classmethod
+    def validate_browser_version_update(cls, value: object) -> object:
+        return normalize_version(value)
+
+    @field_validator("release_channel", mode="before")
+    @classmethod
+    def reject_null_release_channel(cls, value: object) -> object:
+        if value is None:
+            raise ValueError("release_channel cannot be null")
+        return value
+
 
     @field_validator("gpu_family", mode="before")
     @classmethod
@@ -87,6 +127,10 @@ class ReorderRequest(BaseModel):
 class ProfileResponse(BaseModel):
     id: str
     name: str
+    license_key_set: bool = False
+    license_key_masked: str | None = None
+    release_channel: Literal["stable", "preview"] = "stable"
+    browser_version: str | None = None
     fingerprint_seed: int
     proxy: str | None = None
     timezone: str | None = None
@@ -140,8 +184,8 @@ class LaunchResponse(BaseModel):
 
 class StatusResponse(BaseModel):
     running_count: int
-    binary_version: str
-    license_tier: str = "keyless"
+    installed_binary_count: int
+    binary_cache_dir: str
     profiles_total: int
     host_os: HostOS
     runtime_mode: RuntimeMode
@@ -158,16 +202,30 @@ class UpdateCheckResponse(BaseModel):
     release_url: str | None = None
 
 
-class SettingsResponse(BaseModel):
-    license_key_set: bool
-    license_key_masked: str | None = None
-    release_channel: str = "stable"
+class BrowserBinaryResponse(BaseModel):
+    version: str
+    tier: Literal["licensed", "keyless"]
+    path: str
+    size_bytes: int
+    profile_count: int = 0
+    running_count: int = 0
+    in_use: bool = False
 
 
-class SettingsUpdate(BaseModel):
-    # None = leave unchanged; "" = clear the license key (back to keyless).
-    license_key: str | None = None
-    release_channel: str | None = None
+class BrowserBinaryListResponse(BaseModel):
+    cache_dir: str
+    binaries: list[BrowserBinaryResponse] = Field(default_factory=list)
+
+
+class BrowserDownloadResponse(BaseModel):
+    version: str | None = None
+    tier: Literal["licensed", "keyless"]
+    binary_path: str
+
+
+class BrowserCleanupResponse(BaseModel):
+    removed: list[BrowserBinaryResponse] = Field(default_factory=list)
+    reclaimed_bytes: int = 0
 
 
 class ProfileStatusResponse(BaseModel):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,7 @@
 fastapi>=0.115.0
 uvicorn[standard]>=0.34.0
 pydantic>=2.0
-cloakbrowser[geoip]>=0.5.7
+cloakbrowser[geoip]>=0.5.8
 websockets>=14.0
 httpx>=0.27.0
 # Native window shell for the frozen app (WKWebView on macOS, WebView2 on

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sys
 import types
 from pathlib import Path
+import os
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -22,10 +23,16 @@ _mock_cloakbrowser.launch_persistent_context_async = AsyncMock()  # type: ignore
 _mock_config = types.ModuleType("cloakbrowser.config")
 _mock_config.CHROMIUM_VERSION = "0.0.0-test"  # type: ignore[attr-defined]
 _mock_config.get_chromium_version = lambda: "0.0.0-test"  # type: ignore[attr-defined]
+_mock_config.get_platform_tag = lambda: "linux-x64"  # type: ignore[attr-defined]
+_mock_config.get_cache_dir = lambda: Path(  # type: ignore[attr-defined]
+    os.environ.get("CLOAKBROWSER_CACHE_DIR", "/tmp/cloakbrowser-test-cache")
+)
+_mock_config.get_effective_version = lambda **kwargs: None  # type: ignore[attr-defined]
 
-# BrowserManager.resolve_binary_status() (run in the lifespan) imports these.
 _mock_download = types.ModuleType("cloakbrowser.download")
-_mock_download.ensure_binary = MagicMock()  # type: ignore[attr-defined]
+_mock_download.ensure_binary = MagicMock(  # type: ignore[attr-defined]
+    return_value="/tmp/cloakbrowser-test-cache/chromium-145.0.7632.109.2/chrome"
+)
 
 _mock_license = types.ModuleType("cloakbrowser.license")
 _mock_license.resolve_license_key = lambda key=None: key  # type: ignore[attr-defined]

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -11,6 +11,7 @@ from starlette.testclient import TestClient
 
 from backend import main
 from backend.browser_manager import RunningProfile
+from backend.binary_cache import PreparedBinary
 from backend.runtime import RuntimeConfig
 
 
@@ -232,17 +233,14 @@ def test_stop_not_running(app_client: TestClient):
 
 
 def test_system_status(app_client: TestClient):
-    # Clear any leaked running profiles from prior tests
     main.browser_mgr.running.clear()
-
-    # Create a profile so profiles_total > 0
-    app_client.post("/api/profiles", json={"name": "Status Test"})
-    resp = app_client.get("/api/status")
-    assert resp.status_code == 200
-    data = resp.json()
+    response = app_client.get("/api/status")
+    assert response.status_code == 200
+    data = response.json()
     assert data["running_count"] == 0
-    assert data["binary_version"] == "0.0.0-test"
-    assert data["profiles_total"] >= 1
+    assert data["installed_binary_count"] >= 0
+    assert data["binary_cache_dir"]
+    assert data["profiles_total"] >= 0
 
 
 # ── Launch Args ─────────────────────────────────────────────────────────────
@@ -689,90 +687,93 @@ def _same_origin_request_allows(headers: dict[str, str]) -> bool:
     return main._same_origin_request(_fake_request(headers))
 
 
-# ── Settings ─────────────────────────────────────────────────────────────────
+# ── Per-profile browser configuration ────────────────────────────────────────
 
 
-@pytest.fixture()
-def settings_env(tmp_db: Path, monkeypatch: pytest.MonkeyPatch):
-    """Isolate settings.json into the temp dir and neutralise the binary
-    re-resolve (which would validate/download a real Pro build)."""
-    from backend import settings_store
-
-    path = tmp_db / "settings.json"
-    monkeypatch.setattr(settings_store, "_settings_path", lambda: path)
-    monkeypatch.setattr(main.browser_mgr, "resolve_binary_status", MagicMock())
-    # Known baseline so masking/clearing is deterministic.
-    monkeypatch.setattr(main.browser_mgr, "license_key", None)
-    monkeypatch.setattr(main.browser_mgr, "release_channel", "stable")
-    return path
-
-
-def test_get_settings_no_key(app_client: TestClient, settings_env: Path):
-    resp = app_client.get("/api/settings")
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["license_key_set"] is False
-    assert data["license_key_masked"] is None
-    assert data["release_channel"] == "stable"
-
-
-def test_get_settings_masks_key(app_client: TestClient, settings_env: Path):
-    main.browser_mgr.license_key = "cb_ba5f52e422b142a68bc3088f5cbb63aa"
-    resp = app_client.get("/api/settings")
-    data = resp.json()
+def test_profile_browser_settings_are_masked(app_client: TestClient):
+    key = "cb_ba5f52e422b142a68bc3088f5cbb63aa"
+    response = app_client.post(
+        "/api/profiles",
+        json={
+            "name": "Licensed",
+            "license_key": key,
+            "release_channel": "preview",
+            "browser_version": "148.0.7778.215.2",
+        },
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert "license_key" not in data
     assert data["license_key_set"] is True
-    masked = data["license_key_masked"]
-    # Recognisable but not the whole key.
-    assert masked == "cb_ba…63aa"
-    assert "b142a68bc3088" not in masked
+    assert data["license_key_masked"] == "cb_ba…63aa"
+    assert data["release_channel"] == "preview"
+    assert data["browser_version"] == "148.0.7778.215.2"
 
 
-def test_put_settings_persists_and_hot_applies(
-    app_client: TestClient, settings_env: Path
+def test_profile_license_key_can_be_cleared(app_client: TestClient):
+    created = app_client.post(
+        "/api/profiles", json={"name": "Licensed", "license_key": "cb_test_key"}
+    ).json()
+    response = app_client.put(
+        f"/api/profiles/{created['id']}", json={"license_key": None}
+    )
+    assert response.status_code == 200
+    assert response.json()["license_key_set"] is False
+
+
+def test_profile_rejects_invalid_browser_version(app_client: TestClient):
+    response = app_client.post(
+        "/api/profiles", json={"name": "Bad version", "browser_version": "latest"}
+    )
+    assert response.status_code == 422
+
+
+def test_download_profile_browser(app_client: TestClient, monkeypatch: pytest.MonkeyPatch):
+    profile_id = app_client.post(
+        "/api/profiles", json={"name": "Prepare"}
+    ).json()["id"]
+    prepared = PreparedBinary(
+        version="145.0.7632.109.2",
+        tier="keyless",
+        binary_path="/cache/chromium-145.0.7632.109.2/chrome",
+        cache_dir="/cache/chromium-145.0.7632.109.2",
+    )
+    prepare = AsyncMock(return_value=prepared)
+    monkeypatch.setattr(main.browser_mgr, "prepare_binary", prepare)
+
+    response = app_client.post(f"/api/profiles/{profile_id}/browser/download")
+
+    assert response.status_code == 200
+    assert response.json()["version"] == "145.0.7632.109.2"
+    prepare.assert_awaited_once()
+
+
+def test_list_and_cleanup_browser_cache(
+    app_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ):
-    key = "cb_ba5f52e422b142a68bc3088f5cbb63aa"
-    resp = app_client.put("/api/settings", json={"license_key": key})
-    assert resp.status_code == 200
-    # Hot-applied to the live browser manager.
-    assert main.browser_mgr.license_key == key
-    main.browser_mgr.resolve_binary_status.assert_called_once()
-    # Persisted to settings.json.
-    import json
+    binary = {
+        "version": "145.0.7632.109.2",
+        "tier": "keyless",
+        "path": "/cache/chromium-145.0.7632.109.2",
+        "size_bytes": 123,
+        "profile_count": 0,
+        "running_count": 0,
+        "in_use": False,
+    }
+    monkeypatch.setattr(main, "list_installed_binaries", MagicMock(return_value=[binary]))
+    monkeypatch.setattr(
+        main,
+        "cleanup_unused_binaries",
+        MagicMock(return_value=([binary], 123)),
+    )
 
-    assert json.loads(settings_env.read_text())["license_key"] == key
+    listed = app_client.get("/api/browsers")
+    cleaned = app_client.delete("/api/browsers/unused")
 
-
-def test_put_settings_clears_key(app_client: TestClient, settings_env: Path):
-    key = "cb_ba5f52e422b142a68bc3088f5cbb63aa"
-    main.browser_mgr.license_key = key
-    settings_env.write_text('{"license_key": "%s"}' % key)
-
-    resp = app_client.put("/api/settings", json={"license_key": ""})
-    assert resp.status_code == 200
-    assert main.browser_mgr.license_key is None
-    import json
-
-    assert "license_key" not in json.loads(settings_env.read_text())
-
-
-def test_put_settings_sets_channel(app_client: TestClient, settings_env: Path):
-    resp = app_client.put("/api/settings", json={"release_channel": "preview"})
-    assert resp.status_code == 200
-    assert main.browser_mgr.release_channel == "preview"
-    import json
-
-    assert json.loads(settings_env.read_text())["release_channel"] == "preview"
-
-
-def test_put_settings_rejects_bad_channel(
-    app_client: TestClient, settings_env: Path
-):
-    resp = app_client.put("/api/settings", json={"release_channel": "nightly"})
-    assert resp.status_code == 400
-    # Nothing persisted / applied on rejection.
-    assert main.browser_mgr.release_channel == "stable"
-    assert not settings_env.exists()
-
+    assert listed.status_code == 200
+    assert listed.json()["binaries"] == [binary]
+    assert cleaned.status_code == 200
+    assert cleaned.json()["reclaimed_bytes"] == 123
 
 # ── settings_store + runtime units ───────────────────────────────────────────
 

--- a/backend/tests/test_binary_cache.py
+++ b/backend/tests/test_binary_cache.py
@@ -1,0 +1,58 @@
+"""Tests for per-profile binary selection and cache cleanup."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from backend import binary_cache
+
+
+def test_keyless_profile_defaults_to_legacy_145() -> None:
+    request = binary_cache.profile_binary_request({})
+
+    assert request.license_key is None
+    assert request.browser_version == binary_cache.LEGACY_KEYLESS_VERSION
+    assert request.release_channel == "stable"
+
+
+def test_profile_can_pin_licensed_preview_version() -> None:
+    request = binary_cache.profile_binary_request(
+        {
+            "license_key": " cb_test ",
+            "release_channel": "preview",
+            "browser_version": "148.0.7778.215.2",
+        }
+    )
+
+    assert request.license_key == "cb_test"
+    assert request.browser_version == "148.0.7778.215.2"
+    assert request.release_channel == "preview"
+
+
+def test_cleanup_preserves_referenced_and_running_binaries(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    monkeypatch.setenv("CLOAKBROWSER_CACHE_DIR", str(tmp_path))
+    unused = tmp_path / "chromium-146.0.7680.177.5"
+    referenced = tmp_path / "chromium-145.0.7632.109.2"
+    running = tmp_path / "chromium-148.0.7778.215.2-pro"
+    for directory in (unused, referenced, running):
+        directory.mkdir()
+        (directory / "chrome").write_bytes(b"binary")
+
+    profiles = [{"browser_version": "145.0.7632.109.2"}]
+    sessions = [
+        SimpleNamespace(
+            browser_version="148.0.7778.215.2",
+            binary_tier="licensed",
+        )
+    ]
+
+    removed, reclaimed = binary_cache.cleanup_unused_binaries(profiles, sessions)
+
+    assert [item["version"] for item in removed] == ["146.0.7680.177.5"]
+    assert reclaimed == len(b"binary")
+    assert not unused.exists()
+    assert referenced.exists()
+    assert running.exists()

--- a/backend/tests/test_browser_manager.py
+++ b/backend/tests/test_browser_manager.py
@@ -125,7 +125,9 @@ def test_build_args_no_seed():
 
 
 def test_build_args_platform_comes_from_runtime():
-    assert "--fingerprint-platform=windows" in _mgr._build_fingerprint_args({})
+    docker_args = _mgr._build_fingerprint_args({})
+    assert "--fingerprint-platform=windows" in docker_args
+    assert "--fingerprint-windows-font-metrics" in docker_args
     mac_runtime = RuntimeConfig(
         host_os="macos",
         runtime_mode="native",
@@ -133,7 +135,9 @@ def test_build_args_platform_comes_from_runtime():
         data_dir=Path("/tmp/manager-data"),
     )
     mac_manager = BrowserManager(mac_runtime)
-    assert "--fingerprint-platform=macos" in mac_manager._build_fingerprint_args({})
+    mac_args = mac_manager._build_fingerprint_args({})
+    assert "--fingerprint-platform=macos" in mac_args
+    assert "--fingerprint-windows-font-metrics" not in mac_args
     assert not any(
         "gpu-vendor" in arg
         for arg in mac_manager._build_fingerprint_args({"gpu_family": "nvidia"})
@@ -157,13 +161,14 @@ def test_build_args_screen():
 
 def test_build_args_empty_profile():
     args = _mgr._build_fingerprint_args({})
-    # Docker software rendering + runtime platform.
-    assert len(args) == 2
+    # Docker software rendering, Windows persona, and matching font metrics.
+    assert len(args) == 3
 
 
 def test_native_build_args_do_not_force_software_gl():
     args = BrowserManager(NATIVE_RUNTIME)._build_fingerprint_args({})
     assert "--use-angle=swiftshader" not in args
+    assert "--fingerprint-windows-font-metrics" not in args
 
 
 # ── launch_args appended to extra_args ────────────────────────────────────────

--- a/backend/tests/test_browser_manager.py
+++ b/backend/tests/test_browser_manager.py
@@ -320,9 +320,7 @@ async def test_launch_passes_license_config(monkeypatch, tmp_path: Path):
 
     context = MagicMock(pages=[])
     context.add_init_script = AsyncMock()
-    manager = BrowserManager(
-        NATIVE_RUNTIME, license_key="cb_test", release_channel="preview"
-    )
+    manager = BrowserManager(NATIVE_RUNTIME)
     manager._wait_for_cdp = AsyncMock()
     launch = AsyncMock(return_value=context)
     monkeypatch.setattr(module, "launch_persistent_context_async", launch)
@@ -330,11 +328,15 @@ async def test_launch_passes_license_config(monkeypatch, tmp_path: Path):
     profile = _launch_profile(tmp_path)
     profile["extension_paths"] = ["/tmp/extension"]
     profile["launch_args"] = ["--raw-flag"]
+    profile["license_key"] = "cb_test"
+    profile["release_channel"] = "preview"
+    profile["browser_version"] = "148.0.7778.215.2"
     await manager.launch(profile)
 
     options = launch.await_args.kwargs
     assert options["license_key"] == "cb_test"
     assert options["release_channel"] == "preview"
+    assert options["browser_version"] == "148.0.7778.215.2"
     assert options["extension_paths"] == ["/tmp/extension"]
     assert options["args"].index("--raw-flag") > options["args"].index("--fingerprint-platform=windows")
 

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -80,6 +80,34 @@ def test_create_profile_minimal(tmp_db: Path):
     assert p["updated_at"] is not None
 
 
+def test_profile_browser_settings_roundtrip(tmp_db: Path):
+    profile = db.create_profile(
+        "Licensed",
+        license_key="cb_test",
+        release_channel="preview",
+        browser_version="148.0.7778.215.2",
+    )
+
+    assert profile["license_key"] == "cb_test"
+    assert profile["release_channel"] == "preview"
+    assert profile["browser_version"] == "148.0.7778.215.2"
+
+
+def test_legacy_browser_settings_migrate_existing_profiles_once(tmp_db: Path):
+    existing = db.create_profile("Existing")
+
+    migrated = db.migrate_legacy_browser_settings("cb_legacy", "preview")
+    first = db.get_profile(existing["id"])
+    db.create_profile("New")
+    repeated = db.migrate_legacy_browser_settings("cb_other", "stable")
+
+    assert migrated == 1
+    assert first["license_key"] == "cb_legacy"
+    assert first["release_channel"] == "preview"
+    assert repeated == 0
+    assert db.list_profiles()[0]["license_key"] is None
+
+
 def test_create_profile_with_seed(tmp_db: Path):
     p = db.create_profile("Seeded", fingerprint_seed=42)
     assert p["fingerprint_seed"] == 42

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -31,6 +31,9 @@ def test_profile_create_minimal():
     assert p.human_preset == "default"
     assert p.extension_paths == []
     assert p.allow_3p_cookies is True
+    assert p.license_key is None
+    assert p.release_channel == "stable"
+    assert p.browser_version is None
 
 
 def test_profile_create_all_fields():
@@ -87,6 +90,28 @@ def test_profile_create_invalid_human_preset():
 def test_profile_create_invalid_color_scheme():
     with pytest.raises(ValidationError):
         ProfileCreate(name="Bad", color_scheme="auto")
+
+
+def test_profile_browser_version_validation():
+    profile = ProfileCreate(
+        name="Pinned",
+        license_key=" cb_test ",
+        release_channel="preview",
+        browser_version="148.0.7778.215.2",
+    )
+    assert profile.license_key == "cb_test"
+    assert profile.browser_version == "148.0.7778.215.2"
+
+    with pytest.raises(ValidationError):
+        ProfileCreate(name="Bad", browser_version="latest")
+
+
+def test_profile_update_can_explicitly_clear_browser_credentials():
+    update = ProfileUpdate(license_key=None, browser_version=None)
+    assert update.model_dump(exclude_unset=True) == {
+        "license_key": None,
+        "browser_version": None,
+    }
 
 
 # ── ProfileUpdate ────────────────────────────────────────────────────────────

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,5 +8,4 @@ services:
     environment:
       # Values come from the manager-root .env (compose reads it automatically).
       - AUTH_TOKEN=${AUTH_TOKEN:-}
-      - CLOAKBROWSER_LICENSE_KEY=${CLOAKBROWSER_LICENSE_KEY:-}
-      - CLOAKBROWSER_RELEASE_CHANNEL=${CLOAKBROWSER_RELEASE_CHANNEL:-stable}
+      - CLOAKBROWSER_CACHE_DIR=${CLOAKBROWSER_CACHE_DIR:-/data/binaries}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,11 @@ set -e
 # Initialize data directories
 mkdir -p /data/profiles
 
+# Refresh fonts supplied through the private runtime mount.
+if [ -d /usr/local/share/fonts/windows ]; then
+    fc-cache -f /usr/local/share/fonts/windows >/dev/null
+fi
+
 # Kill stale processes from previous container runs
 pkill -f 'Xvnc :[0-9]' 2>/dev/null || true
 pkill -f 'cloakbrowser.*chrome' 2>/dev/null || true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Initialize data directories
-mkdir -p /data/profiles
+mkdir -p /data/profiles "${CLOAKBROWSER_CACHE_DIR:-/data/binaries}"
 
 # Refresh fonts supplied through the private runtime mount.
 if [ -d /usr/local/share/fonts/windows ]; then

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -250,7 +250,7 @@ function AppContent({ authRequired, onLogout }: AppContentProps) {
       {settingsOpen && (
         <SettingsPanel
           onClose={() => setSettingsOpen(false)}
-          onSaved={setSystemStatus}
+          onChanged={() => api.getStatus().then(setSystemStatus).catch(() => undefined)}
         />
       )}
       {updateInfo?.update_available && !updateDismissed && (
@@ -337,51 +337,20 @@ function AppContent({ authRequired, onLogout }: AppContentProps) {
 
         {/* Content */}
         <div className="flex-1 overflow-y-auto overscroll-contain">
-          {view === "empty" &&
-            ((systemStatus?.license_tier ?? "keyless") === "keyless" ? (
-              <div className="flex items-center justify-center h-full px-6">
-                <div className="max-w-sm text-center">
-                  <p className="text-sm font-medium text-gray-200">No license key set</p>
-                  <p className="mt-1.5 text-sm text-gray-500">
-                    You're running the free keyless build. Add a key to run the
-                    latest Pro build.
-                  </p>
-                  <div className="mt-5 flex flex-col items-center gap-2">
-                    <button
-                      onClick={() => setSettingsOpen(true)}
-                      className="btn-primary w-56"
-                    >
-                      Enter a key in Settings
-                    </button>
-                    <a
-                      href="https://cloakbrowser.dev/free"
-                      target="_blank"
-                      rel="noreferrer"
-                      className="btn-secondary w-56"
-                    >
-                      Get a free key
-                    </a>
-                    <a
-                      href="https://cloakbrowser.dev/#pricing"
-                      target="_blank"
-                      rel="noreferrer"
-                      className="text-xs text-gray-500 hover:text-gray-300"
-                    >
-                      See Pro plans &rarr;
-                    </a>
-                  </div>
-                  <p className="mt-6 text-xs text-gray-600">
-                    Or select a profile or create a new one to continue keyless.
-                  </p>
-                </div>
+          {view === "empty" && (
+            <div className="flex items-center justify-center h-full px-6">
+              <div className="max-w-sm text-center">
+                <p className="text-sm font-medium text-gray-200">Select or create a profile</p>
+                <p className="mt-1.5 text-sm text-gray-500">
+                  Each profile owns its license key, release channel, and browser version.
+                  Keyless profiles use the legacy Chromium 145 build by default.
+                </p>
+                <button onClick={handleNew} className="btn-primary mt-5 w-56">
+                  Create profile
+                </button>
               </div>
-            ) : (
-              <div className="flex items-center justify-center h-full">
-                <div className="text-center">
-                  <p className="text-gray-500 text-sm">Select a profile or create a new one</p>
-                </div>
-              </div>
-            ))}
+            </div>
+          )}
 
           {view === "create" && (
             <ProfileForm
@@ -400,6 +369,7 @@ function AppContent({ authRequired, onLogout }: AppContentProps) {
               viewerMode={systemStatus?.viewer_mode ?? null}
               onSave={handleUpdate}
               onDelete={handleDelete}
+              onBrowserPrepared={() => api.getStatus().then(setSystemStatus).catch(() => undefined)}
               onReset={handleReset}
               onDuplicate={handleDuplicate}
               onCancel={() => {

--- a/frontend/src/components/ProfileForm.tsx
+++ b/frontend/src/components/ProfileForm.tsx
@@ -17,6 +17,7 @@ interface ProfileFormProps {
   onDelete?: () => Promise<void>;
   onReset?: () => Promise<void>;
   onDuplicate?: () => Promise<void>;
+  onBrowserPrepared?: () => void;
   onCancel: () => void;
 }
 
@@ -40,11 +41,14 @@ const TAG_COLORS = [
   "#ec4899", // pink
 ];
 
-export function ProfileForm({ profile, hostOs, viewerMode, onSave, onDelete, onReset, onDuplicate, onCancel }: ProfileFormProps) {
+export function ProfileForm({ profile, hostOs, viewerMode, onSave, onDelete, onReset, onDuplicate, onBrowserPrepared, onCancel }: ProfileFormProps) {
   const isEdit = profile !== null;
 
   const [form, setForm] = useState<ProfileCreateData>({
     name: "",
+    license_key: null,
+    release_channel: "stable",
+    browser_version: null,
     screen_width: 1920,
     screen_height: 1080,
     gpu_family: "auto",
@@ -73,6 +77,9 @@ export function ProfileForm({ profile, hostOs, viewerMode, onSave, onDelete, onR
   const [duplicating, setDuplicating] = useState(false);
   const [testingProxy, setTestingProxy] = useState(false);
   const [proxyTest, setProxyTest] = useState<ProxyTestResult | null>(null);
+  const [browserPreparing, setBrowserPreparing] = useState(false);
+  const [browserMessage, setBrowserMessage] = useState<string | null>(null);
+  const [browserError, setBrowserError] = useState<string | null>(null);
   const savedTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const resetTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
@@ -89,6 +96,9 @@ export function ProfileForm({ profile, hostOs, viewerMode, onSave, onDelete, onR
     if (profile) {
       setForm({
         name: profile.name,
+        license_key: undefined,
+        release_channel: profile.release_channel,
+        browser_version: profile.browser_version,
         fingerprint_seed: profile.fingerprint_seed,
         proxy: profile.proxy,
         timezone: profile.timezone,
@@ -140,6 +150,25 @@ export function ProfileForm({ profile, hostOs, viewerMode, onSave, onDelete, onR
       setTestingProxy(false);
     }
   };
+  const handlePrepareBrowser = async () => {
+    if (!profile) return;
+    setBrowserPreparing(true);
+    setBrowserMessage(null);
+    setBrowserError(null);
+    try {
+      await onSave(form);
+      const result = await api.downloadProfileBrowser(profile.id);
+      setBrowserMessage(
+        `${result.tier === "licensed" ? "Licensed" : "Keyless"} browser ${result.version ?? "external"} is ready.`,
+      );
+      onBrowserPrepared?.();
+    } catch (err) {
+      setBrowserError(err instanceof Error ? err.message : "Failed to prepare browser");
+    } finally {
+      setBrowserPreparing(false);
+    }
+  };
+
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -371,6 +400,86 @@ export function ProfileForm({ profile, hostOs, viewerMode, onSave, onDelete, onR
             </div>
           </div>
         </section>
+        {/* Browser */}
+        <section>
+          <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Browser</h3>
+          <div className="space-y-3">
+            <div>
+              <label className="label">CloakBrowser license key</label>
+              <div className="flex gap-2">
+                <input
+                  className="input flex-1 font-mono"
+                  type="password"
+                  autoComplete="off"
+                  spellCheck={false}
+                  value={typeof form.license_key === "string" ? form.license_key : ""}
+                  onChange={(event) => set("license_key", event.target.value || undefined)}
+                  placeholder={
+                    profile?.license_key_set && form.license_key !== null
+                      ? `Current: ${profile.license_key_masked ?? "set"} — type to replace`
+                      : "Leave empty for the legacy keyless browser"
+                  }
+                />
+                {profile?.license_key_set && form.license_key !== null && (
+                  <button type="button" className="btn-secondary text-xs" onClick={() => set("license_key", null)}>
+                    Remove key
+                  </button>
+                )}
+              </div>
+              {form.license_key === null && profile?.license_key_set && (
+                <p className="mt-1 text-xs text-amber-400">The saved license key will be removed.</p>
+              )}
+              <p className="mt-1 text-xs text-gray-500">
+                The key belongs only to this profile. Keyless profiles default to legacy Chromium 145.
+              </p>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="label">Release channel</label>
+                <select
+                  className="input"
+                  value={form.release_channel ?? "stable"}
+                  onChange={(event) => set("release_channel", event.target.value as "stable" | "preview")}
+                >
+                  <option value="stable">Stable</option>
+                  <option value="preview">Preview</option>
+                </select>
+              </div>
+              <div>
+                <label className="label">Browser version</label>
+                <input
+                  className="input font-mono"
+                  value={form.browser_version ?? ""}
+                  onChange={(event) => set("browser_version", event.target.value || null)}
+                  placeholder={form.license_key || profile?.license_key_set ? "Latest" : "145.0.7632.109.2"}
+                  pattern="[0-9]+(\.[0-9]+){3,4}"
+                  title="Use a full numeric Chromium version"
+                />
+              </div>
+            </div>
+            <p className="text-xs text-gray-500">
+              Leave empty for automatic selection. Exact pins work for paid or keyless profiles; free keys always use the latest licensed build.
+            </p>
+
+            {isEdit && (
+              <div className="flex items-center gap-3">
+                <button
+                  type="button"
+                  onClick={handlePrepareBrowser}
+                  disabled={browserPreparing}
+                  className="btn-secondary flex items-center gap-1.5"
+                >
+                  {browserPreparing && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+                  {browserPreparing ? "Preparing browser..." : "Save and download/update now"}
+                </button>
+                {browserMessage && <span className="text-xs text-emerald-400">{browserMessage}</span>}
+                {browserError && <span className="text-xs text-red-400">{browserError}</span>}
+              </div>
+            )}
+          </div>
+        </section>
+
 
         {/* Network */}
         <section>

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -1,162 +1,125 @@
-import { useEffect, useState } from "react";
-import { Loader2, X } from "lucide-react";
-import { api, type ManagerSettings, type SystemStatus } from "../lib/api";
+import { useCallback, useEffect, useState } from "react";
+import { Loader2, Trash2, X } from "lucide-react";
+import { api, type BrowserBinaryList } from "../lib/api";
 
 interface SettingsPanelProps {
   onClose: () => void;
-  onSaved: (status: SystemStatus) => void;
+  onChanged: () => void;
 }
 
-/**
- * In-app settings — replaces hand-editing a .env for the native app.
- * v1 exposes the license key + release channel; the field list is kept flat so
- * future settings drop in as new rows.
- */
-export function SettingsPanel({ onClose, onSaved }: SettingsPanelProps) {
-  const [current, setCurrent] = useState<ManagerSettings | null>(null);
-  const [licenseKey, setLicenseKey] = useState("");
-  const [channel, setChannel] = useState<"stable" | "preview">("stable");
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+function formatBytes(bytes: number): string {
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
 
-  useEffect(() => {
-    api
-      .getSettings()
-      .then((s) => {
-        setCurrent(s);
-        setChannel(s.release_channel === "preview" ? "preview" : "stable");
-      })
-      .catch((err) =>
-        setError(err instanceof Error ? err.message : "Failed to load settings"),
-      );
+export function SettingsPanel({ onClose, onChanged }: SettingsPanelProps) {
+  const [cache, setCache] = useState<BrowserBinaryList | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [cleaning, setCleaning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      setCache(await api.listBrowsers());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load browser cache");
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
-  const handleSave = async () => {
-    setSaving(true);
-    setError(null);
-    try {
-      // Send license_key only when the user typed something (empty input =
-      // leave the existing key untouched, not clear it).
-      const payload: { license_key?: string; release_channel: string } = {
-        release_channel: channel,
-      };
-      if (licenseKey.trim()) payload.license_key = licenseKey.trim();
-      const status = await api.updateSettings(payload);
-      onSaved(status);
-      onClose();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to save settings");
-    } finally {
-      setSaving(false);
-    }
-  };
+  useEffect(() => {
+    void load();
+  }, [load]);
 
-  const handleClearKey = async () => {
-    setSaving(true);
+  const cleanup = async () => {
+    if (!confirm("Delete every downloaded browser version not referenced by a profile or running session?")) return;
+    setCleaning(true);
     setError(null);
+    setMessage(null);
     try {
-      const status = await api.updateSettings({ license_key: "" });
-      onSaved(status);
-      onClose();
+      const result = await api.cleanupUnusedBrowsers();
+      setMessage(
+        result.removed.length === 0
+          ? "No unused browser versions found."
+          : `Removed ${result.removed.length} version(s) and reclaimed ${formatBytes(result.reclaimed_bytes)}.`,
+      );
+      await load();
+      onChanged();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to clear key");
+      setError(err instanceof Error ? err.message : "Failed to clean browser cache");
     } finally {
-      setSaving(false);
+      setCleaning(false);
     }
   };
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
-      onClick={onClose}
-    >
-      <div
-        className="w-full max-w-md rounded-lg border border-border bg-surface-1 shadow-xl"
-        onClick={(e) => e.stopPropagation()}
-      >
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4" onClick={onClose}>
+      <div className="w-full max-w-2xl rounded-lg border border-border bg-surface-1 shadow-xl" onClick={(event) => event.stopPropagation()}>
         <div className="flex items-center justify-between border-b border-border px-4 py-3">
-          <h2 className="text-sm font-semibold">Settings</h2>
-          <button
-            onClick={onClose}
-            className="text-gray-500 hover:text-gray-300"
-            title="Close"
-          >
+          <h2 className="text-sm font-semibold">Browser cache</h2>
+          <button onClick={onClose} className="text-gray-500 hover:text-gray-300" title="Close">
             <X className="h-4 w-4" />
           </button>
         </div>
 
         <div className="space-y-4 p-4">
           <div>
-            <label className="label">CloakBrowser license key</label>
-            <input
-              className="input font-mono"
-              type="password"
-              autoComplete="off"
-              spellCheck={false}
-              value={licenseKey}
-              onChange={(e) => setLicenseKey(e.target.value)}
-              placeholder={
-                current?.license_key_set
-                  ? `Current: ${current.license_key_masked ?? "set"} — type to replace`
-                  : "cb_… (leave empty to run the free keyless build)"
-              }
-            />
+            <label className="label">Storage path</label>
+            <code className="block break-all rounded-md bg-surface-2 px-3 py-2 text-xs text-gray-300">
+              {cache?.cache_dir ?? "Loading..."}
+            </code>
             <p className="mt-1 text-xs text-gray-500">
-              One key per Manager instance — every profile shares its seat pool.{" "}
-              <a
-                href="https://cloakbrowser.dev/free"
-                target="_blank"
-                rel="noreferrer"
-                className="text-accent hover:underline"
-              >
-                Get a free key
-              </a>
-              .
+              Set CLOAKBROWSER_CACHE_DIR to place this cache on an external path or volume.
             </p>
           </div>
 
           <div>
-            <label className="label">Release channel</label>
-            <select
-              className="input"
-              value={channel}
-              onChange={(e) =>
-                setChannel(e.target.value === "preview" ? "preview" : "stable")
-              }
-            >
-              <option value="stable">Stable</option>
-              <option value="preview">Preview (early access)</option>
-            </select>
+            <div className="mb-2 flex items-center justify-between">
+              <label className="label mb-0">Installed versions</label>
+              <button onClick={cleanup} disabled={loading || cleaning} className="btn-danger flex items-center gap-1.5">
+                {cleaning ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Trash2 className="h-3.5 w-3.5" />}
+                Clean unused
+              </button>
+            </div>
+            {loading ? (
+              <div className="flex items-center gap-2 py-6 text-sm text-gray-500">
+                <Loader2 className="h-4 w-4 animate-spin" /> Loading browser cache...
+              </div>
+            ) : cache?.binaries.length ? (
+              <div className="max-h-80 space-y-2 overflow-y-auto">
+                {cache.binaries.map((binary) => (
+                  <div key={`${binary.tier}-${binary.version}`} className="rounded-md border border-border bg-surface-2 p-3">
+                    <div className="flex items-center justify-between gap-3">
+                      <div>
+                        <div className="font-mono text-sm text-gray-200">{binary.version}</div>
+                        <div className="mt-1 text-xs text-gray-500">
+                          {binary.tier === "licensed" ? "Licensed" : "Keyless"} · {formatBytes(binary.size_bytes)}
+                        </div>
+                      </div>
+                      <span className={binary.in_use ? "text-xs text-emerald-400" : "text-xs text-gray-500"}>
+                        {binary.in_use
+                          ? `${binary.profile_count} profile(s), ${binary.running_count} running`
+                          : "Unused"}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="py-6 text-sm text-gray-500">No browser binary has been downloaded yet.</p>
+            )}
           </div>
 
+          {message && <p className="text-xs text-emerald-400">{message}</p>}
           {error && <p className="text-xs text-red-400">{error}</p>}
         </div>
 
-        <div className="flex items-center justify-between gap-2 border-t border-border px-4 py-3">
-          {current?.license_key_set ? (
-            <button
-              onClick={handleClearKey}
-              disabled={saving}
-              className="text-xs text-gray-500 hover:text-red-400 disabled:opacity-50"
-            >
-              Remove key
-            </button>
-          ) : (
-            <span />
-          )}
-          <div className="flex items-center gap-2">
-            <button onClick={onClose} disabled={saving} className="btn-secondary">
-              Cancel
-            </button>
-            <button
-              onClick={handleSave}
-              disabled={saving}
-              className="btn-primary flex items-center gap-1.5"
-            >
-              {saving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-              <span>{saving ? "Applying…" : "Save"}</span>
-            </button>
-          </div>
+        <div className="flex justify-end border-t border-border px-4 py-3">
+          <button onClick={onClose} className="btn-secondary">Close</button>
         </div>
       </div>
     </div>

--- a/frontend/src/components/SystemStatusBadge.tsx
+++ b/frontend/src/components/SystemStatusBadge.tsx
@@ -1,38 +1,19 @@
 import { AlertTriangle } from "lucide-react";
 import type { SystemStatus } from "../lib/api";
 
-const TIER_LABEL: Record<string, string> = {
-  pro: "Pro",
-  free: "Free key",
-  keyless: "Free (keyless)",
-};
-
-const TIER_COLOR: Record<string, string> = {
-  pro: "text-emerald-400",
-  free: "text-sky-400",
-  keyless: "text-amber-400",
-};
-
-/** Small always-visible badge showing which binary/tier the Manager is running. */
+/** Small always-visible badge showing the persistent browser cache state. */
 export function SystemStatusBadge({ status }: { status: SystemStatus | null }) {
   if (!status) return null;
 
-  const tier = status.license_tier || "keyless";
-  const title =
-    tier === "keyless"
-      ? "No license key set. Running the free keyless build. Open Settings to add a key for the latest Pro build."
-      : `${TIER_LABEL[tier] ?? tier} license — running ${status.binary_version}`;
-
+  const count = status.installed_binary_count;
   return (
     <span
       className="flex items-center gap-1.5 text-xs text-gray-500"
-      title={title}
+      title={`Browser cache: ${status.binary_cache_dir}`}
     >
-      <span className={TIER_COLOR[tier] ?? "text-gray-400"}>
-        {TIER_LABEL[tier] ?? tier}
+      <span className={count > 0 ? "text-emerald-400" : "text-gray-500"}>
+        {count} browser {count === 1 ? "version" : "versions"}
       </span>
-      <span className="text-gray-600">·</span>
-      <span className="font-mono">{status.binary_version}</span>
       {status.windows_fonts_complete === false && (
         <span className="flex items-center gap-1 text-amber-400" title={`Windows persona fonts incomplete: ${status.windows_fonts_present ?? 0}/${status.windows_fonts_required ?? 0} found`}>
           <AlertTriangle className="h-3.5 w-3.5" /> Fonts incomplete

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -9,6 +9,10 @@ export type ViewerMode = "native-window" | "vnc";
 export interface Profile {
   id: string;
   name: string;
+  license_key_set: boolean;
+  license_key_masked: string | null;
+  release_channel: "stable" | "preview";
+  browser_version: string | null;
   fingerprint_seed: number;
   proxy: string | null;
   timezone: string | null;
@@ -52,6 +56,9 @@ export interface LaunchDenial {
 
 export interface ProfileCreateData {
   name: string;
+  license_key?: string | null;
+  release_channel?: "stable" | "preview";
+  browser_version?: string | null;
   fingerprint_seed?: number | null;
   proxy?: string | null;
   timezone?: string | null;
@@ -97,8 +104,8 @@ export interface ProxyTestResult {
 
 export interface SystemStatus {
   running_count: number;
-  binary_version: string;
-  license_tier: string; // "pro" | "free" | "keyless"
+  installed_binary_count: number;
+  binary_cache_dir: string;
   profiles_total: number;
   host_os: HostOS;
   runtime_mode: RuntimeMode;
@@ -115,15 +122,30 @@ export interface UpdateInfo {
   release_url: string | null;
 }
 
-export interface ManagerSettings {
-  license_key_set: boolean;
-  license_key_masked: string | null;
-  release_channel: string; // "stable" | "preview"
+export interface BrowserBinary {
+  version: string;
+  tier: "licensed" | "keyless";
+  path: string;
+  size_bytes: number;
+  profile_count: number;
+  running_count: number;
+  in_use: boolean;
 }
 
-export interface SettingsUpdate {
-  license_key?: string | null; // omit = unchanged; "" = clear
-  release_channel?: string | null;
+export interface BrowserBinaryList {
+  cache_dir: string;
+  binaries: BrowserBinary[];
+}
+
+export interface BrowserDownloadResult {
+  version: string | null;
+  tier: "licensed" | "keyless";
+  binary_path: string;
+}
+
+export interface BrowserCleanupResult {
+  removed: BrowserBinary[];
+  reclaimed_bytes: number;
 }
 
 export class ApiError extends Error {
@@ -244,12 +266,14 @@ export const api = {
   shutdown: () =>
     request<{ ok: boolean; message?: string }>("/api/shutdown", { method: "POST" }),
 
-  getSettings: () => request<ManagerSettings>("/api/settings"),
+  listBrowsers: () => request<BrowserBinaryList>("/api/browsers"),
 
-  updateSettings: (data: SettingsUpdate) =>
-    request<SystemStatus>("/api/settings", {
-      method: "PUT",
-      body: JSON.stringify(data),
+  cleanupUnusedBrowsers: () =>
+    request<BrowserCleanupResult>("/api/browsers/unused", { method: "DELETE" }),
+
+  downloadProfileBrowser: (id: string) =>
+    request<BrowserDownloadResult>(`/api/profiles/${id}/browser/download`, {
+      method: "POST",
     }),
 
   setClipboard: (id: string, text: string) =>


### PR DESCRIPTION
## Changes
- install CloakBrowser's recommended emoji and CJK baseline fonts in the Docker image
- remove the incomplete and network-fragile XP-era core-font installer
- refresh privately mounted Windows fonts at container startup
- enable Windows font metrics for Linux-hosted Windows personas
- document the private read-only font mount and cover the managed launch flag

## Verification
- `python -m pytest backend/tests -q` — 241 passed
- `npm test -- --run` — 20 passed
- `npm run build` — passed
- `podman build -t cloakbrowser-manager:local .` — passed
- container smoke test: `/api/health` returned `status: ok`; Noto Color Emoji and IPAGothic resolved; Docker launch args included `--fingerprint-windows-font-metrics`